### PR TITLE
DOC: Fix ITK long name case mismatch.

### DIFF
--- a/SoftwareGuide/Latex/DesignAndFunctionality/Filtering.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/Filtering.tex
@@ -108,7 +108,7 @@ these filters are the $3 \times 3$ filters in 2D images. Convolution masks
 based on these neighborhoods can perform diverse tasks ranging from noise
 reduction, to differential operations, to mathematical morphology.
 
-The Insight toolkit implements an elegant approach to neighborhood-based image
+The Insight Toolkit implements an elegant approach to neighborhood-based image
 filtering.  The input image is processed using a special iterator called the
 \doxygen{NeighborhoodIterator}. This iterator is capable of moving over all the
 pixels in an image and, for each position, it can address the pixels in a local


### PR DESCRIPTION
Make the ITK long name used in the SW Guide (Insight Toolkit) be consistent
concerning its case: change `Insight toolkit` for `Insight Toolkit`.

Change-Id: Icd004cf94bf8fc04c314100f05d7ac82fad24f1b