### PR TITLE
DOC: Add Documentation Style section.

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -3920,3 +3920,20 @@ style where appropriate.
 
 For writing CMake scripts, the community member is referred to the standard
 CMake style.
+
+
+\section{Documentation Style}
+\label{sec:DocumentationStyle}
+
+The Insight Software Consortium has adopted the following guidelines for
+producing supplemental documentation (documentation not produced by Doxygen):
+\begin{itemize}
+\item The common denominator for documentation is either PDF or HTML. All
+documents in the system should be available in these formats, even if they are
+mastered by another system.
+\item Presentations are acceptable in Microsoft PowerPoint format.
+\item Administrative and planning documents are acceptable in Microsoft Word
+format (either \code{.docx} or \code{.rtf}).
+\item Larger documents, such as the user's or developer's guide, are written in
+\LaTeX.
+\end{itemize}


### PR DESCRIPTION
Add a `Documentation Style` section, following the discussion in
Change Id: 22691. In fact, it had been foreseen in the `Overview` section
in previous versions of the Coding Style Guide.

Change-Id: Ic9b938e51f53880e6605f454df2183cf443aeb3a