### PR TITLE
DOC: Add a CMake Style item to the Overview section.

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -70,6 +70,7 @@ values.
 \item \textbf{Writing Tests}: additional rules specific to writing tests in ITK.
 \item \textbf{Doxygen Documentation System}: basic Doxygen formatting
 instructions.
+\item \textbf{CMake Style}: guidelines to write CMake files.
 \item \textbf{Documentation Style}: a brief section describing the
 documentation philosophy adopted by the Insight Software Consortium.
 \end{itemize}


### PR DESCRIPTION
The `CMake Style` section was not being listed in the `Overview` section.

Change-Id: I547ab74c31a9e71128200eb856f470289de5f0d4