### PR TITLE
COMP: Use the xcolor package instead of color

### DIFF
--- a/SoftwareGuide/Latex/00-Preamble-Common.tex
+++ b/SoftwareGuide/Latex/00-Preamble-Common.tex
@@ -1,6 +1,6 @@
 \usepackage[dvips]{graphicx}
 \usepackage{times}
-\usepackage{color}
+\usepackage{xcolor}
 \usepackage{listings}
 \usepackage{minted}
 \usepackage{setspace}


### PR DESCRIPTION
This addresses the build error:

  ! LaTeX Error: Undefined color `shadecolor'.

on Debian 9 (Stretch).

Change-Id: I2a0badc9450706ec031df609f4aaa105293cd6b0