### PR TITLE
DOC: Fix use of \center vs. \centering in figures.

### DIFF
--- a/SoftwareGuide/Latex/Architecture/ImageAdaptors.tex
+++ b/SoftwareGuide/Latex/Architecture/ImageAdaptors.tex
@@ -5,7 +5,7 @@
 \index{ImageAdaptors}
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.8\textwidth]{ImageAdaptorConcept.eps}
 \itkcaption[ImageAdaptor concept]{ The difference between using a
 CastImageFilter and an ImageAdaptor.  ImageAdaptors

--- a/SoftwareGuide/Latex/DesignAndFunctionality/ConfidenceConnectedOnBrainWeb.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/ConfidenceConnectedOnBrainWeb.tex
@@ -9,14 +9,14 @@ Gradient Anistropic diffusion was applied to smooth the image. The filter used 2
 Figure \ref{fig:3DregionGrowingScreenshot1} shows the rendered volume. Figure \ref{fig:SlicesBrainWeb} shows an axial, saggital and a coronal slice of the volume.
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.6\textwidth]{3DregionGrowingScreenshot1.eps}
 \itkcaption[Whitematter Confidence Connected segmentation.]{White matter segmented using Confidence Connected region growing.}
 \label{fig:3DregionGrowingScreenshot1}
 \end{figure}
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=\textwidth]{SlicesBrainWebConfidenceConnected.eps}
 \itkcaption[Axial, sagittal, and coronal slice of Confidence Connected segmentation.]{Axial, sagittal and coronal slice segmented using Confidence Connected region growing.}
 \label{fig:SlicesBrainWeb}

--- a/SoftwareGuide/Latex/DesignAndFunctionality/DeformableRegistration.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/DeformableRegistration.tex
@@ -13,7 +13,8 @@
 \subsection{FEM-Based Image Registration}
 \label{sec:FEMBasedImageRegistration}
 
-\begin{figure} \center
+\begin{figure}
+\centering
 \includegraphics[width=0.44\textwidth]{DeformableRegistration1CheckerboardBefore.eps}
 \includegraphics[width=0.44\textwidth]{DeformableRegistration1CheckerboardAfter.eps}
 \itkcaption[FEM-based deformable registration results]{Checkerboard comparisons

--- a/SoftwareGuide/Latex/DesignAndFunctionality/DeformableRegistration4OnBrain.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/DeformableRegistration4OnBrain.tex
@@ -52,14 +52,14 @@ deformation field is in close agreement to the one generated from the Thin
 plate spline warping.
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.6\textwidth]{ParaviewScreenshot5.eps}
 \itkcaption[Deformation field output]{Resulting deformation field that maps the moving image to the fixed image.}
 \label{fig:DeformationFieldOutput}
 \end{figure}
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.44\textwidth]{DeformableRegistration4DiffBefore.eps}
 \includegraphics[width=0.44\textwidth]{DeformableRegistration4DiffAfter.eps}
 \itkcaption[Difference image]{Difference image from a slice before and after registration.}

--- a/SoftwareGuide/Latex/DesignAndFunctionality/HybridSegmentationMethods.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/HybridSegmentationMethods.tex
@@ -123,7 +123,7 @@ connectedness, Voronoi diagrams and deformable models, respectively.
 
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.8\textwidth]{HybridSegmentationEngine1.eps}
 \itkcaption[Hybrid Segmentation Engine]{The hybrid segmentation engine.}
 \label{fig:ComponentsofaHybridSegmentationApproach}
@@ -131,7 +131,7 @@ connectedness, Voronoi diagrams and deformable models, respectively.
 
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.8\textwidth]{FuzzyConnectednessClassDiagram1.eps}
 \itkcaption[FuzzyConectedness Filter Diagram]{Inheritance diagram for the fuzzy connectedness filter.}
 \label{fig:UMLClassDiagramoftherFuzzyConnectednessFilter}
@@ -139,7 +139,7 @@ connectedness, Voronoi diagrams and deformable models, respectively.
 
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.8\textwidth]{FuzzyConnectednessCollaborationDiagram1.eps}
 \itkcaption[Fuzzy Connectedness Segmentation Diagram]{Inputs and outputs to
 FuzzyConnectednessImageFilter segmentation algorithm.}
@@ -147,7 +147,7 @@ FuzzyConnectednessImageFilter segmentation algorithm.}
 \end{figure}
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.8\textwidth]{VoronoiSegmentationClassDiagram1.eps}
 \itkcaption[Voronoi Filter class diagram]{Inheritance diagram for the Voronoi
 segmentation filters.}
@@ -155,7 +155,7 @@ segmentation filters.}
 \end{figure}
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.8\textwidth]{VoronoiSegmentationCollaborationDiagram1.eps}
 \itkcaption[Voronoi Diagram Filter classes]{Classes used by the Voronoi
 segmentation filters.}
@@ -164,7 +164,7 @@ segmentation filters.}
 
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.8\textwidth]{VoronoiSegmentationCollaborationDiagram2.eps}
 \itkcaption[Voronoi Diagram Segmentation]{Input and output to the
 VoronoiSegmentationImageFilter.}
@@ -173,7 +173,7 @@ VoronoiSegmentationImageFilter.}
 
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.8\textwidth]{FuzzyVoronoiCollaborationDiagram1.eps}
 \itkcaption[Fuzzy Connectedness and Voronoi Diagram Classification]{Integration
  of the fuzzy connectedness and Voronoi segmentation filters.}
@@ -181,7 +181,7 @@ VoronoiSegmentationImageFilter.}
 \end{figure}
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.8\textwidth]{FuzzyVoronoiDeformableCollaborationDiagram1.eps}
 \itkcaption[Fuzzy Connectedness, Voronoi diagram, and Deformable
 Models]{Integration of the fuzzy connectedness, Voronoi, and

--- a/SoftwareGuide/Latex/DesignAndFunctionality/IO.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/IO.tex
@@ -20,21 +20,21 @@ To better understand the IO architecture, please refer to Figures
 \ref{fig:ImageIOFactoriesClassDiagram}.
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=\textwidth]{ImageIOCollaborationDiagram.eps}
 \itkcaption[Collaboration diagram of the ImageIO classes]{Collaboration diagram
 of the ImageIO classes.} \label{fig:ImageIOCollaborationDiagram}
 \end{figure}
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=\textwidth]{ImageIOFactoriesUseCases.eps}
 \itkcaption[Use cases of ImageIO factories] {Use cases of ImageIO factories.}
 \label{fig:ImageIOFactoriesUseCases}
 \end{figure}
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=\textwidth]{ImageIOFactoriesClassDiagram.eps}
 \itkcaption[Class diagram of ImageIO factories] {Class diagram of the ImageIO
 factories.}

--- a/SoftwareGuide/Latex/DesignAndFunctionality/ImageInterpolators.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/ImageInterpolators.tex
@@ -3,7 +3,7 @@
 %
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=\textwidth]{ImageOverlap.eps}
 \itkcaption[Mapping moving image to fixed image in Registration]{ The moving
 image is mapped into the fixed image space under some spatial

--- a/SoftwareGuide/Latex/DesignAndFunctionality/ModelBasedRegistration.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/ModelBasedRegistration.tex
@@ -59,7 +59,7 @@ contained in the image. The adapted model becomes a condensed representation of
 the essential elements of the anatomical structure.
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.8\textwidth]{ModelToImageRegistrationConcept.eps}
 \itkcaption[Model to Image Registration Framework Concept]{Basic concept of
   Model-to-Image registration.  A simplified geometrical model (ellipse) is

--- a/SoftwareGuide/Latex/DesignAndFunctionality/Optimizers.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/Optimizers.tex
@@ -4,7 +4,7 @@
 
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=\textheight,angle=90]{Optimizersv4Hierarchy.eps}
 \itkcaption[Class diagram of the Optimizers hierarchy in ITKv4]{Class diagram of the
 optimizersv4 hierarchy.}

--- a/SoftwareGuide/Latex/DesignAndFunctionality/Registration.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/Registration.tex
@@ -29,7 +29,7 @@ Registration is treated as an optimization problem with the goal of finding the
 spatial mapping that will bring the moving image into alignment with the fixed image.
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.8\textwidth]{RegistrationComponentsDiagram.eps}
 \itkcaption[A Typical Registration Framework Components]{The basic components
 of a typical registration framework are two input images, a transform, a
@@ -59,7 +59,7 @@ Various ITKv4 registration components are illustrated in Figure
 \emph{data objects}, while those with solid borders show \emph{process objects}.
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.8\textwidth]{ITKv4RegistrationComponentsDiagram.eps}
 \itkcaption[Registration Framework Components]{The basic components of the ITKv4
 registration framework.}
@@ -112,7 +112,7 @@ These concepts are discussed in this section through a general example shown in
 Figure~\ref{fig:ImageRegistrationCoordinateSystemsDiagram}.
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.75\textwidth]{ImageRegistrationCoordinateSystemsDiagram.eps}
 \itkcaption[Registration Coordinate Systems]{Different coordinate systems
 involved in the image registration process. Note that the transform being

--- a/SoftwareGuide/Latex/DesignAndFunctionality/Transforms.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/Transforms.tex
@@ -17,7 +17,7 @@ in ITK for representing basic spatial concepts.
 \label{sec:GeometricalObjects}
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.9\textwidth]{GeometricalObjects.eps}
 \itkcaption[Geometrical representation objects in ITK]{Geometric
 representation objects in ITK.}

--- a/SoftwareGuide/Latex/DesignAndFunctionality/VisualizingDeformationFieldsUsingParaview.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/VisualizingDeformationFieldsUsingParaview.tex
@@ -23,21 +23,21 @@ Reduce the number of glyphs by reducing the number in {\it Max. Number of Glyphs
 Figure \ref{fig:ParaviewScreenshot3} shows the vector field visualized using Paraview by thresholding the vector magnitudes by 2.1 and restricting the number of glyphs to 100.
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=\textwidth]{ParaviewScreenshot1.eps}
 \itkcaption[Deformation field magnitudes]{Deformation field magnitudes displayed using Paraview}
 \label{fig:ParaviewScreenshot1}
 \end{figure}
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.3\textwidth]{ParaviewScreenshot2.eps}
 \itkcaption[Calculator]{Calculators and filters may be used to compute the vector magnitude, compose vectors etc.}
 \label{fig:ParaviewScreenshot2}
 \end{figure}
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=\textwidth]{ParaviewScreenshot3.eps}
 \itkcaption[Visualized Def field]{Deformation field visualized using Paraview after thresholding and subsampling.}
 \label{fig:ParaviewScreenshot3}
@@ -56,7 +56,7 @@ where the subscripts denote partial derivatives of f.
 We may now proceed as before to visualize the deformation field using Paraview as shown in Figure \ref{fig:ParaviewScreenshot4}.
 
 \begin{figure}
-\center
+\centering
 \includegraphics[width=0.7\textwidth]{ParaviewScreenshot4.eps}
 \itkcaption[Visualized Def field4]{3D Deformation field visualized using Paraview.}
 \label{fig:ParaviewScreenshot4}


### PR DESCRIPTION
According to the following LaTeX recommendations, `\centering` should be
used, rather than `\center` or `\begin{center}...\end{center}` which may
have undesired side-effects:

http://texblog.net/latex-archive/floats/center-centering/

https://tex.stackexchange.com/questions/23650/when-should-we-use-begincenter-instead-of-centering

https://tex.stackexchange.com/questions/2651/should-i-use-center-or-centering-for-figures-and-tables

Change-Id: I171a7866ac1fb00271ccc756c71a9dc8cb349564