### PR TITLE
DOC: Fix ParseCxxExamples.py script location in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Following is a brief description of the build process:
      [ImageMagick]; the resulting EPS files are saved in `Art/Generated`
      directory of the binary output directory.
   4. A Python script
-     [`./SoftwareGuide/ParseCxxExamples.py`](https://github.com/InsightSoftwareConsortium/ITKSoftwareGuide/blob/master/SoftwareGuide/ParseCxxExamples.py)
+     [`./SoftwareGuide/Examples/ParseCxxExamples.py`](https://github.com/InsightSoftwareConsortium/ITKSoftwareGuide/blob/master/SoftwareGuide/Examples/ParseCxxExamples.py)
      is invoked to extract the comments in the ITK examples source file
      delimited with `BeginLaTeX`, `EndLaTeX` and `BeginCodeSnippet`,
      `EndCodeSnippet` and generate LaTeX files which are copied into the


### PR DESCRIPTION
Fix ParseCXXExamples.py script location in README.md file.

Looks like commit ee89a28ec2f0b9276f931023ad1184a46cb5e28b overwrote the
previous path renaming done in commit 6541f4781346efaeaaa90de1ca3f4b040eca9687

Change-Id: I3563baf27ffc43de16408e25b68705ad3b4ecc35