### PR TITLE
ENH: Use ccache in the CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,28 @@ jobs:
     steps:
       - checkout:
           path: /ITKSoftwareGuide
+      - restore_cache:
+          keys:
+            - ccache-{{ arch }}-{{ .Branch }}
+            - ccache-{{ arch }}-master
+      - run:
+          name: CCache initialization
+          command: |
+            ccache --show-stats
+            ccache --zero-stats
+            ccache --max-size=2.0G
       - run:
           name: Run CTest build and report to CDash
           no_output_timeout: 2.0h
           command: /cmd.sh
+      - run:
+          name: ccache stats
+          when: always
+          command: |
+            ccache --show-stats
+      - save_cache:
+          key: 'ccache-{{ arch }}-{{ .Branch }}-{{ epoch }}'
+          paths: [ "/root/.ccache" ]
 
 workflows:
     version: 2


### PR DESCRIPTION
Change-Id: I758d9812416d4df2c6153ce4a2a69142fe258c4e
Suggested-by: Bradley Lowekamp <blowekamp@mail.nih.gov>