### PR TITLE
ENH: Require cmake minimum version to be 3.9.5.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.8.2) #2.8.10 needed for ExternalProject Simplification
-cmake_policy(VERSION 2.8.10)
+cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
+cmake_policy(VERSION 3.9.5)
 
 set(PRIMARY_PROJECT_NAME ITKSoftwareGuide)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12) #2.8.10 needed for ExternalProject Simplification
+cmake_minimum_required(VERSION 3.8.2) #2.8.10 needed for ExternalProject Simplification
 cmake_policy(VERSION 2.8.10)
 
 set(PRIMARY_PROJECT_NAME ITKSoftwareGuide)

--- a/SoftwareGuide/CMakeLists.txt
+++ b/SoftwareGuide/CMakeLists.txt
@@ -24,7 +24,7 @@
 # images, if not the images are expected to be present in the Art/ folder
 # in PNG/XFIG/JPEG/EPS format.
 #
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(SoftwareGuide C)
 

--- a/SoftwareGuide/CMakeLists.txt
+++ b/SoftwareGuide/CMakeLists.txt
@@ -24,7 +24,8 @@
 # images, if not the images are expected to be present in the Art/ folder
 # in PNG/XFIG/JPEG/EPS format.
 #
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
+cmake_policy(VERSION 3.9.5)
 
 project(SoftwareGuide C)
 

--- a/SoftwareGuide/Cover/Source/CMakeLists.txt
+++ b/SoftwareGuide/Cover/Source/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( VWSegmentation )
 

--- a/SoftwareGuide/Cover/Source/CMakeLists.txt
+++ b/SoftwareGuide/Cover/Source/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.8.2)
-
+cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
+cmake_policy(VERSION 3.9.5)
+ 
 project( VWSegmentation )
 
 find_package( ITK REQUIRED )

--- a/SoftwareGuide/Examples/CMakeLists.txt
+++ b/SoftwareGuide/Examples/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
+cmake_policy(VERSION 3.9.5)
+ 
 project(Examples C)
 
 set(_required_vars

--- a/SoftwareGuide/Examples/CMakeLists.txt
+++ b/SoftwareGuide/Examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.8.2)
 project(Examples C)
 
 set(_required_vars

--- a/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
+++ b/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
@@ -61,7 +61,7 @@ When CMake starts processing a module, it begins with the top level
 contain
 
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cmake}
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.8.2)
 project(MyModule)
 
 set(MyModule_LIBRARIES MyModule)

--- a/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
+++ b/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
@@ -61,7 +61,9 @@ When CMake starts processing a module, it begins with the top level
 contain
 
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cmake}
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
+cmake_policy(VERSION 3.9.5)
+
 project(MyModule)
 
 set(MyModule_LIBRARIES MyModule)

--- a/SoftwareGuide/Latex/Introduction/Installation.tex
+++ b/SoftwareGuide/Latex/Introduction/Installation.tex
@@ -205,7 +205,7 @@ download the source code and build CMake on your system. Follow the instructions
 provided on the CMake web page for downloading and installing the software. The
 minimum version of CMake has been evolving along with the version of ITK. For
 example, the current version of ITK (\ITKVERSIONMAJORMINORPATCH) requires the minimum
-CMake version to be 3.8.2.
+CMake version to be 3.9.5.
 
 CMake provides a terminal-based interface (Figure \ref{fig:CMakeGUI})
 on platforms support the \code{curses} library. For most platforms CMake also

--- a/SoftwareGuide/Latex/Introduction/Installation.tex
+++ b/SoftwareGuide/Latex/Introduction/Installation.tex
@@ -205,7 +205,7 @@ download the source code and build CMake on your system. Follow the instructions
 provided on the CMake web page for downloading and installing the software. The
 minimum version of CMake has been evolving along with the version of ITK. For
 example, the current version of ITK (\ITKVERSIONMAJORMINORPATCH) requires the minimum
-CMake version to be 2.8.12.
+CMake version to be 3.8.2.
 
 CMake provides a terminal-based interface (Figure \ref{fig:CMakeGUI})
 on platforms support the \code{curses} library. For most platforms CMake also


### PR DESCRIPTION
Require CMake minimum version to be 3.9.5 following ITKv5 requiring
C++11:
https://discourse.itk.org/t/minimum-cmake-version-update/585

Change-Id: Id29122ae88d449854fb22aea0048224e9025d85c