### PR TITLE
DOC: Warn against linking static libraries multiple times.

### DIFF
--- a/SoftwareGuide/Latex/Introduction/Installation.tex
+++ b/SoftwareGuide/Latex/Introduction/Installation.tex
@@ -403,7 +403,10 @@ Static libraries are preferred when creating a stand-alone executable. An
 application can be distributed as a single file when statically linked.
 Additional effort is not required to package library dependencies, configure the
 system to find library dependencies at runtime, or define symbol export
-specifications.
+specifications. However, care should be taken to only link static libraries
+\textit{once} into the binaries used by an application. Failure to due so can
+result in duplicated global variables and, consequently, undefined or
+undesirable behavior.
 
 Shared libraries should be used when ITK is linked to more than one binary in
 an application. This reduces binary size and ensures that singleton


### PR DESCRIPTION
Unless special precautions are taken, as done with the ITK Python wrapping,
linking static libraries multiple times into binaries used in the same
executable can cause issues due to duplicate global variables, like the
GlobalTimeStamp or the ObjectFactory.

Change-Id: I761deb8361d94c38d4028c5d8f6c6780bd98b863

CC: @jjomier 