### PR TITLE
DOC: Update the ITK mailing list to point to discourse.

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -81,7 +81,7 @@ Please discuss with the ITK community members if you wish to add, modify, or
 delete the rules described in these guidelines.
 
 See \href{http://www.itk.org/ITK/help/mailing.html}{http://www.itk.org/ITK/help/mailing.html}
-for more information about joining the ITK community members mailing list. This
+for more information about joining the ITK community members discussion. This
 forum is one of the best venues in which to propose changes to these style
 guidelines.
 

--- a/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
+++ b/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
@@ -320,7 +320,7 @@ file's contents are only the MD5SUM hash of its target. Content links for data
 files in a Git distributed version control repository prevent repository
 bloat. To obtain content links, register an account with the \texttt{ITK}
 community at \url{https://midas3.kitware.com} and request upload permissions
-on the ITK mailing list. The content links may also be created locally: once
+on the ITK discussion. The content links may also be created locally: once
 the actual file at issue has been placed in the corresponding directory, run
 CMake configuration, and CMake provides the desired \texttt{.md5} extension
 content link file.

--- a/SoftwareGuide/Latex/Introduction/Installation.tex
+++ b/SoftwareGuide/Latex/Introduction/Installation.tex
@@ -78,7 +78,7 @@ There are two different ways to access the ITK source code:
   \item[Periodic releases]{Official releases are available on the ITK web
     site\footnote{\url{https://itk.org/ITK/resources/software.html}}.
     They are released twice a year,
-    and announced on the ITK web pages and mailing list.
+    and announced on the ITK web pages and discussion.
     However, they may not provide the latest and greatest features of the
     toolkit.}
   \item[Continuous repository checkout]{Direct access to the Git source code
@@ -145,7 +145,7 @@ git pull
 Once you obtain the software you are ready to configure and compile it (see
 Section \ref{sec:CMakeforITK} on page \pageref{sec:CMakeforITK}). First,
 however, we recommend reading the following sections that describe the
-organization of the software and joining the mailing list.
+organization of the software and joining the discussion.
 
 \subsection{Data}
 \label{sec:Data}
@@ -579,5 +579,5 @@ documentation\footnote{\url{https://cmake.org/documentation/}}.
 By this point you have successfully configured and compiled ITK, and created
 your first simple program! If you have experienced any difficulties while
 following the instructions provided in this section, please join the community
-mailing list (see Section~\ref{sec:JoinMailList} on
-page \pageref{sec:JoinMailList}) and post questions there.
+discussion (see Section~\ref{sec:JoinDiscussion} on
+page \pageref{sec:JoinDiscussion}) and post questions there.

--- a/SoftwareGuide/Latex/Introduction/Introduction.tex
+++ b/SoftwareGuide/Latex/Introduction/Introduction.tex
@@ -28,7 +28,7 @@ community surrounding ITK has a great impact on the evolution of the software.
 The community can make significant contributions to ITK by providing code
 reviews, bug patches, feature patches, new classes, documentation, and
 discussions. Please feel free to contribute your ideas through the ITK
-community mailing list.
+community discussion.
 
 \section{Organization}
 \label{sec:Organization}
@@ -178,18 +178,32 @@ release are available at \url{https://itk.org/Doxygen44/html/}.
 
 \section{The Insight Community and Support}
 \label{sec:AdditionalResources}
-\label{sec:JoinMailList}
+\label{sec:JoinDiscussion}
 
-\index{ITK!mailing list}
-\index{mailing list}
+\index{ITK!discussion}
+\index{discussion}
 
-Joining the community mailing list is strongly recommended. This is one of the
+Joining the community discussion is strongly recommended. This is one of the
 primary resources for guidance and help regarding the use of the toolkit. You
 can subscribe to the community list online at
 
 \begin{center}
-\url{https://www.itk.org/ITK/help/mailing.html}
+\url{https://discourse.itk.org/}
 \end{center}
+
+ITK transitioned to \href{Discourse}{https://www.discourse.org/} on September
+2017. \href{Discourse}{https://www.discourse.org/} is a next generation, open
+source discussion platform that functions as a mailing list, discussion forum,
+and long-form chat room. Discourse is a simple, modern, and fun platform that
+facilitates civilized discussions.
+
+ITK maintainers developed a
+\href{Getting Started Guide}{https://discourse.itk.org/t/getting-started-with-discourse/22}
+to help people joining the discussion, subscribing to updates, or setting their
+preferences.
+
+The previous mailing list resources can be reached at
+\texttt{https://itk.org/ITK/help/mailing.html}.
 
 ITK was created from its inception as a collaborative, community
 effort. Research, teaching, and commercial uses of the toolkit are
@@ -197,8 +211,8 @@ expected. If you would like to participate in the community, there are a
 number of possibilities. For details on participation, see Part III of this book.
 
 \begin{itemize}
-       \item Interaction with other community members is encouraged on the
-       mailing lists by both asking as answering questions. When issues are
+       \item Interaction with other community members is encouraged on the ITK
+       discussion by both asking as answering questions. When issues are
        discovered, patches submitted to the code review system are welcome.
        Performing code reviews, even by novice members, is encouraged.
        Improvements and extensions to the documentation are also welcome.


### PR DESCRIPTION
Update the link to join the mailing list to directly point at the
[ITK discussion](https://discourse.itk.org/).

Provide a short explanation about the transition from the mailing list to
[Discourse](https://www.discourse.org/).

Prefer `ITK dicussion` to `mailing list`.

Update the section header and the corresponding labels to better reflect
the change.

Resolves #22

Change-Id: I435161457e1f622c4492cc715c4efcd48ef3284d