### PR TITLE
BUG: Fix missing cross-refs.

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -2480,8 +2480,7 @@ virtual unsigned int GetSplitInternal( unsigned int dim,
 
 Lines exceeding the recommended line length in ITK must be split in the
 necessary amount of lines. This policy is enforced by the KWStyle pre-commit
-hooks (see Section~\ref{subsec:KitwareStyle} on
-page~\pageref{subsec:KitwareStyle}).
+hooks (see Section~\ref{subsec:KWStyle} on page~\pageref{subsec:KWStyle}).
 
 If a line has to be split, the following preference order is established in ITK:
 \begin{itemize}
@@ -2868,7 +2867,7 @@ MinimumMaximumImageCalculator< TInputImage >
 
 The file must be terminated by a (preferably single) blank line.
 This policy is enforced by the KWStyle pre-commit hooks (see Section
-~\ref{subsec:KitwareStyle} on page~\pageref{subsec:KitwareStyle}).
+~\ref{subsec:KWStyle} on page~\pageref{subsec:KWStyle}).
 
 
 \section{Increment/decrement Operators}


### PR DESCRIPTION
Use the right label to cross-ref to the `KWStyle` section.

Change-Id: Ie7bfd326a6b07a172a65efa29ea996cf8a6ac1f9