### PR TITLE
BUG: Fix Table 2.1 exceeding the page width.

### DIFF
--- a/SoftwareGuide/Latex/Introduction/Installation.tex
+++ b/SoftwareGuide/Latex/Introduction/Installation.tex
@@ -85,10 +85,12 @@ these compiler environments.
 \end{itemize}
 
 
-\ref{tab:CompileSupportTimeline} prints the compiler support timeline in ITK at
-the time of writing this guide:
-\begin{table}
+Table~\ref{tab:CompileSupportTimeline} prints the compiler support timeline in
+ITK at the time of writing this guide.
+
+\begin{table}[h]
 \begin{center}
+\resizebox{\textwidth}{!}{
 \begin{tabular}{c c c c c c c c c c c c c c c c c}
 \toprule
 Compiler & 2011 & 2012 & 2013 & 2014 & 2015 & 2016 & 2017 & 2018 & 2019 & 2020 & 2021 & 2022 & 2023 & 2024 & 2025 & 2026 \\
@@ -100,6 +102,7 @@ GCC 4.4 & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellc
 GCC 4.9 & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{yellow} & \cellcolor{red} \\
 \bottomrule
 \end{tabular}
+}
 \end{center}
 \itkcaption[ITK Compiler Support Timeline]{ITK Compiler Support Timeline.
 \label{tab:CompileSupportTimeline}}
@@ -107,7 +110,7 @@ GCC 4.9 & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellc
 
 \textbf{Legend}:
 
-\begin{table}
+\begin{table}[h]
 \begin{center}
 \begin{tabular}{l}
 \cellcolor{itkTableCellGreen}Fully supported \\


### PR DESCRIPTION
Fix `Table 2.1` in chapter `CONFIGURING AND BUILDING ITK` exceeding the
page width.

Fixes #62.