### PR TITLE
BUG: Fix the introduction text missing from the output PDF file.

### DIFF
--- a/SoftwareGuide/Latex/Introduction/Introduction.tex
+++ b/SoftwareGuide/Latex/Introduction/Introduction.tex
@@ -1,9 +1,10 @@
 \chapter{Welcome}
 \label{chapter:Introduction}
 
-Welcome to the \emph{Insight Segmentation and Registration Toolkit (ITK)
-Software Guide}. This book has been updated for ITK \ITKVERSIONMAJORMINORPATCH
-\ and later versions of the Insight Toolkit software.
+Welcome to the
+\emph{Insight Segmentation and Registration Toolkit (ITK) Software Guide}. This
+book has been updated for ITK \ITKVERSIONMAJORMINORPATCH\ and later versions of
+the Insight Toolkit software.
 
 ITK is an open-source, object-oriented software system for image processing,
 segmentation, and registration. Although it is large and complex, ITK is


### PR DESCRIPTION
Fix the missing text from the *Introduction* due to a `\emph{}`
environment being split across lines.

Fixes #70.