### PR TITLE
DOC: Improve formatting of an ITK class in the Contributors section.

### DIFF
--- a/SoftwareGuide/Latex/04-Contributors.tex
+++ b/SoftwareGuide/Latex/04-Contributors.tex
@@ -57,7 +57,7 @@ the finite element method.
 hybrid segmentation methods.
 
 {\bf Mark Foskey} contributed the examples on the
-AutomaticTopologyMeshSource class.
+ \doxygen{AutomaticTopologyMeshSource} class.
 
 {\bf Mathieu Malaterre} contributed the entire section on the description and
 use of DICOM readers and writers based on the GDCM library. He also contributed


### PR DESCRIPTION
Use proper LaTeX formatting when mentioning an ITK class in the
`Contributors` section.