### PR TITLE
DOC: Update and fix typos in Introduction section.

### DIFF
--- a/SoftwareGuide/Latex/Introduction/Introduction.tex
+++ b/SoftwareGuide/Latex/Introduction/Introduction.tex
@@ -255,9 +255,9 @@ partners---University of North Carolina (UNC), University of Tennessee (UT)
 (Ross Whitaker subsequently moved to University of Utah), and University of
 Pennsylvania (UPenn). The Principle Investigators for these partners were,
 respectively, Bill Lorensen at GE CRD, Will Schroeder at Kitware, Vikram
-Chalana at Insightful, Stephen Aylward with Luis Iba\~{n}ez at UNC (Luis is now
-at Kitware), Ross Whitaker with Josh Cates at UT (both now at Utah), and
-Dimitri Metaxas at UPenn (now at Rutgers). In addition, several
+Chalana at Insightful, Stephen Aylward with Luis Ib\'{a}\~{n}ez at UNC (Luis
+is now at Google), Ross Whitaker with Josh Cates at UT (both now at Utah),
+and Dimitri Metaxas at UPenn (now at Rutgers). In addition, several
 subcontractors rounded out the consortium including Peter Raitu at Brigham \&
 Women's Hospital, Celina Imielinska and Pat Molholt at Columbia University,
 Jim Gee at UPenn's Grasp Lab, and George Stetten at the University of


### PR DESCRIPTION
Update Luis Ibáñez's current position and fix the accent in his name in
the `Introduction` section.