### PR TITLE
DOC: Remove refs to hybrid segmentation methods (patent issues).

### DIFF
--- a/SoftwareGuide/Latex/04-Contributors.tex
+++ b/SoftwareGuide/Latex/04-Contributors.tex
@@ -51,11 +51,6 @@ their application.
 {\bf Tessa Sundaram} contributed the section on deformable registration using
 the finite element method.
 
-{\bf YinPeng Jin} contributed the examples on  hybrid segmentation methods.
-
-{\bf Celina Imielinska} authored the section describing the principles of
-hybrid segmentation methods.
-
 {\bf Mark Foskey} contributed the examples on the
 AutomaticTopologyMeshSource class.
 


### PR DESCRIPTION
Remove the references to hybrid segmentation methods from the
`Contrbutors` section.

The hybrid segmentation methods (namely the
`itk::SimpleFuzzyConnectedness*` filters and also possibly
`itk::VectorFuzzyConnectednessImageFilter`) were ruled out from ITK due
to patent issues as of ITKv4.

The commit that removed them:
https://github.com/InsightSoftwareConsortium/ITK/commit/6a61bb88493735815d469c144b5b707eb4c93b29

The ITKv4 release notes that notified about it:
https://itk.org/Wiki/ITK/Release_4/Removed_or_renamed_classes
and
https://itk.org/Wiki/ITK_Release_4/Migration_Plan/Release_Notes/ITKv4_Final_Release_Notes
and
https://itk.org/Wiki/ITK/Release_4/Migration_Plan/Release_Notes