### PR TITLE
DOC: Change mailing list address for discourse address.

### DIFF
--- a/SoftwareGuide/Latex/00-Preamble-Common.tex
+++ b/SoftwareGuide/Latex/00-Preamble-Common.tex
@@ -130,7 +130,7 @@ colorlinks,linkcolor={blue},citecolor={blue},urlcolor={blue},
 
 \authoraddress{
   \url{https://itk.org}\\
-  Email: \email{community@itk.org}
+  \url{https://discourse.itk.org/}
 }
 
 \date{\today}


### PR DESCRIPTION
Change the community mailing list address in the book covers for the ITK
discourse discussion forum address.