### PR TITLE
COMP: Set the minimum required CMake version to 3.10.2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
-cmake_policy(VERSION 3.9.5)
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_policy(VERSION 3.10.2)
 
 set(PRIMARY_PROJECT_NAME ITKSoftwareGuide)
 

--- a/SoftwareGuide/CMakeLists.txt
+++ b/SoftwareGuide/CMakeLists.txt
@@ -24,8 +24,8 @@
 # images, if not the images are expected to be present in the Art/ folder
 # in PNG/XFIG/JPEG/EPS format.
 #
-cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
-cmake_policy(VERSION 3.9.5)
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_policy(VERSION 3.10.2)
 
 project(SoftwareGuide C)
 

--- a/SoftwareGuide/Cover/Source/CMakeLists.txt
+++ b/SoftwareGuide/Cover/Source/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
-cmake_policy(VERSION 3.9.5)
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_policy(VERSION 3.10.2)
  
 project( VWSegmentation )
 

--- a/SoftwareGuide/Examples/CMakeLists.txt
+++ b/SoftwareGuide/Examples/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
-cmake_policy(VERSION 3.9.5)
- 
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_policy(VERSION 3.10.2)
+
 project(Examples C)
 
 set(_required_vars

--- a/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
+++ b/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
@@ -61,8 +61,8 @@ When CMake starts processing a module, it begins with the top level
 contain
 
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cmake}
-cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
-cmake_policy(VERSION 3.9.5)
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_policy(VERSION 3.10.2)
 
 project(MyModule)
 


### PR DESCRIPTION
As agreed in:
https://discourse.itk.org/t/cmake-update/870/

Set the `cmake_minimum_required` to version **3.10.2**.