### PR TITLE
BUG: Fix hyperlink bugs in Community and Support section.

### DIFF
--- a/SoftwareGuide/Latex/Introduction/Introduction.tex
+++ b/SoftwareGuide/Latex/Introduction/Introduction.tex
@@ -196,14 +196,14 @@ can subscribe to the community list online at
 \url{https://discourse.itk.org/}
 \end{center}
 
-ITK transitioned to \href{Discourse}{https://www.discourse.org/} on September
-2017. \href{Discourse}{https://www.discourse.org/} is a next generation, open
+ITK transitioned to \href{https://www.discourse.org/}{Discourse} on September
+2017. \href{https://www.discourse.org/}{Discourse} is a next generation, open
 source discussion platform that functions as a mailing list, discussion forum,
 and long-form chat room. Discourse is a simple, modern, and fun platform that
 facilitates civilized discussions.
 
 ITK maintainers developed a
-\href{Getting Started Guide}{https://discourse.itk.org/t/getting-started-with-discourse/22}
+\href{https://discourse.itk.org/t/getting-started-with-discourse/22}{Getting Started Guide}
 to help people joining the discussion, subscribing to updates, or setting their
 preferences.
 


### PR DESCRIPTION
Fix hyperlink bugs introduced by commit 1298dcb in the `The Insight
Community and Support` section: the text of the hyperlink comes after
the URL in the LaTeX `href` command.