### PR TITLE
DOC: Fix some minor ortography mistakes.

### DIFF
--- a/SoftwareGuide/Latex/04-Contributors.tex
+++ b/SoftwareGuide/Latex/04-Contributors.tex
@@ -76,7 +76,7 @@ the documentation for the initial ITK Version 4 release.
 {\bf Luis Ib\'{a}\~{n}ez} and {\bf S\'{e}bastien Barr\'{e}} designed the
 original Book 1 cover. {\bf Matthew McCormick} and {\bf Brad King} updated the
 code to produce the Book 1 cover for ITK 4 and VTK 6. {\bf Xiaoxiao Liu},
-{\bf Bill Lorensen}, {\bf Luis Ib\'{a}\~{n}ez},and {\bf Matthew McCormick}
+{\bf Bill Lorensen}, {\bf Luis Ib\'{a}\~{n}ez}, and {\bf Matthew McCormick}
 created the 3D printed anatomical objects that were photographed by {\bf
 S\'{e}bastien Barr\'{e}} for the Book 2 cover. {\bf Steve Jordan} designed the
 layout of the covers.

--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -2021,8 +2021,8 @@ names and the following marks:
 \item An opening angle bracket (\code{<}) and the \code{template} keyword.
 \item An opening round bracket (\code{(}) and its preceding word (e.g. in method
 declarations and definitions).
-\item An opening/closing brace (\code{\{}/\code{\}}) and its subsequent/
-preceding word (e.g. when initializing an array).
+\item An opening/closing brace (\code{\{}/\code{\}}) and its
+subsequent/preceding word (e.g. when initializing an array).
 \item An opening or closing square bracket (\code{[}, \code{]} ) and its
 contents (e.g. when specifying the index of an array).
 \item The constant expression termination colon in a \code{switch} statement
@@ -2037,8 +2037,8 @@ To the contrary, a single white space should be added between
 variable or keyword.
 \item A closing angle bracket (\code{>}) and the preceding and subsequent
 words (such as in type aliases).
-\item An opening/closing round bracket (\code{(}/\code{)}) and its subsequent/
-preceding word (e.g. in method argument lists).
+\item An opening/closing round bracket (\code{(}/\code{)}) and its
+subsequent/preceding word (e.g. in method argument lists).
 \item Individual members in a list separated by commas (e.g.
 \code{SizeType size = {{20, 20, 20}}}, or \code{data[i, j]}). The comma must be
 always placed next to a given element, and be followed by the single white space.
@@ -2542,9 +2542,9 @@ However, no empty lines shall be added between:
 \begin{itemize}
 \item The accessor type (\code{public}, \code{protected}, \code{private}) and
 the declaration that immediately follows it.
-\item An opening/closing brace (\code{\{}/\code{\}}) and its subsequent/
-preceding line (e.g. nested namespace braces, method definition and its body,
-control statements, etc).
+\item An opening/closing brace (\code{\{}/\code{\}}) and its
+subsequent/preceding line (e.g. nested namespace braces, method definition and
+its body, control statements, etc).
 \end{itemize}
 
 However, an empty line should exist in a header file (\code{.h})


### PR DESCRIPTION
Fix some minor ortography mistakes:
- Add a white space after a punctuation sign.
- Remove a spare white space after forward slash between two words (was
a matter of LaTeX adding a white space for broken lines).