### PR TITLE
BUG: Fix compiler list time schedule format.

### DIFF
--- a/SoftwareGuide/Latex/Introduction/Installation.tex
+++ b/SoftwareGuide/Latex/Introduction/Installation.tex
@@ -49,12 +49,12 @@ these compiler environments.
 %% We are promising to support ITK building under these compilers even after MS will support the compiler itself.
 \item Visual Studio % https://en.wikipedia.org/wiki/Microsoft_Visual_Studio
   \begin{itemize}
-  \item 2008\[v9.0\] (From 2007 - until 2018)  % November 19, 2007 -- build_name "Win64-VS9-Release-Shared"
-  \item 2010\[v10.0\] (From 2010 - until 2020) % April 12, 2010     -- build_name "Win64-VS10-Release-Shared"
-  \item 2012\[v11.0\] (From 2012 - until 2022) % September 12, 2012 -- buld_name "Win32-VS11-Release-Shared"
-  \item 2013\[v12.0\] (From 2013 - until 2023) % October 17, 2013 -- none-listed
-  %\item 2015\[v14.0\] (From 2015 - until 2023) % July 20, 2015
-  %\item 2016\[v15.0\] (From 2017 - until 2023) % March 7, 2017
+  \item 2008 [v9.0] (From 2007 - until 2018)  % November 19, 2007 -- build_name "Win64-VS9-Release-Shared"
+  \item 2010 [v10.0] (From 2010 - until 2020) % April 12, 2010     -- build_name "Win64-VS10-Release-Shared"
+  \item 2012 [v11.0] (From 2012 - until 2022) % September 12, 2012 -- buld_name "Win32-VS11-Release-Shared"
+  \item 2013 [v12.0] (From 2013 - until 2023) % October 17, 2013 -- none-listed
+  %\item 2015 [v14.0] (From 2015 - until 2023) % July 20, 2015
+  %\item 2016 [v15.0] (From 2017 - until 2023) % March 7, 2017
   \end{itemize}
 %% -we have no nightly builds
 %% \item Intel Compiler Suite  %% https://en.wikipedia.org/wiki/Intel_C%2B%2B_Compiler


### PR DESCRIPTION
The compiler list time schedule in chapter `Configuring and Building
ITK` was being displayed with an awkward layout.

See for example p.10 in a recent build belonging to PR #64:
https://open.cdash.org/upload/8fc8cf811a130b76f66c2b81a3f3027ac17e3b09/ITKSoftwareGuide-Book1.pdf

As explained in:
https://en.wikibooks.org/wiki/LaTeX/Mathematics
the `\[` is a LaTeX shorthand for a displayed equation environment.

This topic removes the unnecessary backward slash escape character.