### PR TITLE
BUG: Fail gracefully in git-pr with too many requests

### DIFF
--- a/Utilities/GitSetup/git-pr
+++ b/Utilities/GitSetup/git-pr
@@ -32,7 +32,11 @@ if [[ $# -lt 1 ]]; then
     repo_name=$(git config -f "$config" --get github.repo-name)
     url="https://api.$host/repos/$organization_name/$repo_name/pulls?sort=updated;direction=desc"
     pr_prompt=$(curl -s "https://api.$host/repos/$organization_name/$repo_name/pulls?sort=updated;direction=desc" \
-      | $python_exe -c "import sys, json; res = json.load(sys.stdin); [print(str(pr['number']) + ': ' + pr['title']) for pr in res];")
+      | $python_exe -c "import sys, json; res = json.load(sys.stdin); [print(str(pr['number']) + ': ' + str(pr['title'])) for pr in res] if 'pr' in res else sys.exit(1);")
+    if [ $? -ne 0 ]; then
+      usage
+      exit 1
+    fi
     echo "$pr_prompt"
     echo ""
     pr_number=$(echo "$pr_prompt" | sed -n -e "s/\([[:alnum:]]\+\).*/\1/p" | tail -n1)


### PR DESCRIPTION
The response can be:

  {'message': "API rate limit exceeded for 97.65.134.139. (But here's the good
  news: Authenticated requests get a higher rate limit. Check out the
  documentation for more details.)", 'documentation_url':
  'https://developer.github.com/v3/#rate-limiting'}