### PR TITLE
BUG: Missing binary Examples folder

### DIFF
--- a/SoftwareGuide/Examples/ParseCxxExamples.py
+++ b/SoftwareGuide/Examples/ParseCxxExamples.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import sys
 import os
+import errno
 import re
 import shlex
 import subprocess
@@ -155,6 +156,15 @@ if __name__ == "__main__":
     print("Processing {0} into {1}  ... \n".format(inputfilename, outputfilename))
 
     thisCodeBlocks = ParseOneFile(inputfilename)
+
+    try:
+        path = os.path.dirname(outputfilename)
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
 
     outPtr = open(outputfilename, 'w')
     outPtr.write(GetPreambleString(inputfilename))


### PR DESCRIPTION
`RunExamples` has been moved from `ITKSoftwareGuide/SoftwareGuide/Examples`
to a CMake `ExternalProject_Add`. This means that the subfolder
`ITKSoftwareGuide/SoftwareGuide/Examples` is not created a configure time
anymore. When Examples are parsed to be converted to `tex` files, the parser
fails to write the generated `tex` file as the output folder does not
exist.