### PR TITLE
ENH: Make the section name appear in footnote 2 .

### DIFF
--- a/SoftwareGuide/Latex/Introduction/Introduction.tex
+++ b/SoftwareGuide/Latex/Introduction/Introduction.tex
@@ -71,7 +71,9 @@ available documentation. By running the examples, one can gain confidence
 in achieving results and is introduced the mechanics of the software system.
 There are three example resources,
 \begin{enumerate}
-  \item the \code{Examples} directory of the ITK source code repository \footnote{\ref{sec:DownloadingITK}}.
+  \item the \code{Examples} directory of the ITK source code repository
+  \footnote{See Section~\nameref{sec:DownloadingITK} on
+  page~\pageref{sec:DownloadingITK})}.
   \item the Examples pages on the ITK Wiki \footnote{\url{https://itk.org/Wiki/ITK/Examples}}
   \item the Sphinx documented ITK Examples \footnote{\url{https://itk.org/ITKExamples}}
 \end{enumerate}


### PR DESCRIPTION
Footnote 2 on page 4 of the current ITK Software Guide PDF version
available at:
https://itk.org/ItkSoftwareGuide.pdf

refers to `Section 2.1. Obtaining the Software`. However, the footnote
only displays the section number `2.1`.

This patch set makes LaTeX display the section name, and also adds
additional information to make it clear that it refers to a resource
within the file itself.