### PR TITLE
BUG: Add missing newline to Test finished notice

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -3367,7 +3367,7 @@ that the test has ended:
 \small
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
 ...
-std::cout << "Test finished.";
+std::cout << "Test finished." << std::endl;
 return EXIT_SUCCESS;
 \end{minted}
 \normalsize


### PR DESCRIPTION
Ensure we have a newline in the test output.