### PR TITLE
DOC: Clarifies that GroupSO replaces SceneSO

### DIFF
--- a/SoftwareGuide/Latex/Architecture/SpatialObjects.tex
+++ b/SoftwareGuide/Latex/Architecture/SpatialObjects.tex
@@ -112,6 +112,9 @@ implemented in ITK.
 \subsection{GroupSpatialObject}
 \label{sec:GroupSpatialObject}
 \input{GroupSpatialObject.tex}
+
+With ITKv5, the \code{GroupSpatialObject} also replaces the
+ \code{SceneSpatialObject}. Much of the functionality is unchanged.
 \input{SceneSpatialObject.tex}
 
 


### PR DESCRIPTION
Detail that GroupSpatialObject in ITKv5 replaces SceneSpatialObject,
and retains nearly identical functionality.

There is a corresponding pull request in ITK: https://github.com/InsightSoftwareConsortium/ITK/pull/1005.