### PR TITLE
DOC: Fix testing macro name

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -3571,7 +3571,7 @@ The following general layout is recommended for ITK unit tests:
 \item \code{foo} class instantiation and basic object checks (e.g.
 \code{ITK\_EXERCISE\_BASIC\_OBJECT\_METHODS}).
 \item \code{foo} class properties' input argument read and test (e.g. using the
-macros in \code{itkTestingMacro.h}, such as \code{ITK\_TEST\_SET\_GET\_OBJECT}, etc.).
+macros in \code{itkTestingMacro.h}, such as \code{ITK\_TEST\_SET\_GET\_VALUE}, etc.).
 \item \code{foo} class \code{Update()}.
 \item Regression checks.
 \item Output image write.


### PR DESCRIPTION
Fix testing macro name: `TEST_SET_GET_OBJECT` does not exist as a testing
macro (or as any other macro in ITK).