### PR TITLE
BUG: Remove CircleCI resource_class specification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2
 jobs:
   build:
-    resource_class: xlarge
     working_directory: /ITKSoftwareGuide-build
     docker:
       - image: insighttoolkit/itksoftwareguide-dashboard:latest


### PR DESCRIPTION
This is now limited to paid plans.