### PR TITLE
ENH: Miscellaneous fixes in introduction and installation

### DIFF
--- a/SoftwareGuide/Latex/Introduction/Installation.tex
+++ b/SoftwareGuide/Latex/Introduction/Installation.tex
@@ -17,7 +17,7 @@ ITK has been developed and tested across different combinations of operating
 systems, compilers, and hardware platforms including Microsoft Windows, Linux on
 various architectures, UNIX, macOS, and Mingw-w64. Dedicated community members and
 Kitware are committed to providing long-term support of the most prevalent
-development environments (Visual Studio, macOS, and Linux) for building ITK:
+development environments (e.g. Clang and Visual Studio) for building ITK.
 
 Compiler variants will be supported for the duration that the associated operating
 system vendors commit to in their long-term stable platforms. For example the gcc
@@ -26,91 +26,18 @@ Apple Clang compilers will mirror the support lifecycle of the compiler by Apple
 the Visual Studio series support will follow lifecycle deprecation of the compiler
 versions.
 
-% List updated according to information provided here:
-% https://www.itk.org/Wiki/ITK_Release_4/Modern_C++#Fully_Committed_to_Support
-
-For example as of 2019 the following time schedule is expected for supporting
-these compiler environments.
-
+For example, the following development and compiler environments are supported
+in ITK for the date at which the document was generated:
 %%
 %% The following compilers should have nightly dashboard in the "Expected builds"
 %% to ensure that support is maintained.
 %%
 \begin{itemize}
-\item GCC
-  \begin{itemize}
-      \item 4.8.2 (From 2015-until 2020)  %% June 26, 2015  -- build_name "Ubuntu-g++-4.8.2-Release"
-      %\item 5.x %% Release date April 22, 2015
-      %\item 6.x %% April 27, 2016
-      %\item 7.x %% May 2, 2017
-   \end{itemize}
-\item Visual Studio % https://en.wikipedia.org/wiki/Microsoft_Visual_Studio
-  \begin{itemize}
-  \item 2015 [v14.X]
-  \item 2017 [v15.X]
-  \end{itemize}
-%% -we have no nightly builds
-%% \item Intel Compiler Suite  %% https://en.wikipedia.org/wiki/Intel_C%2B%2B_Compiler
-%%    \begin{itemize}
-%%      \item 11.x                            % Released in 2008
-%%      \item 12.x (including macOS release)  % Released in 2011
-%%      \item 13.x   %Released in 2012
-%%      \item 14.x   %Released in 2013
-%%      \item 15.x   %Released in 2014
-%%      \item 16.x   %Released in 2015
-%%      \item 17.x does not compile cleanly with macOS  % Released in 2016
-%%      \item 18.x   % $Released in 2018
-%%    \end{itemize}
-
-%% -- we have no nightly builds in Expected,  only Exotic builds, and those are nto passing
-%% \item Win32-mingw-gcc-4.5
-\item Apple Clang
-  \begin{itemize}
-     \item Apple clang-600.0.56 (From 2013 - until 2019) %% mini9.nlm  build_name "MacOSX-Xcode6"build perhaps has this compiler -- listed as unkown
-     \item Apple LLVM version 8.1.0 (clang-802.0.42)  (From 2016 - until 2021) %% Released in 2016, build_name "MacOSX-Clang-Ninja-Release"
-   \end{itemize}
-\item Clang
-    \begin{itemize}
-      \item 3.3 (From 2013 - until 2018) % 17 Jun 2013  -- no build.
-      %%\item 4.0 % 13 March 2017
-      %%\item 5.0 % 7 September 2017
-    \end{itemize}
+\item GCC 4.8 and newer
+\item Visual Studio 2015, 2017, 2019, toolsets 14.x, 15.0, 16.0
+\item Apple Clang 7.0 and newer
+\item Clang 6 and newer
 \end{itemize}
-
-
-Table~\ref{tab:CompileSupportTimeline} prints the compiler support timeline in
-ITK at the time of writing this guide.
-
-\begin{table}[h]
-\begin{center}
-\resizebox{\textwidth}{!}{
-\begin{tabular}{c c c c c c c c c c c c c c c c c}
-\toprule
-Compiler & 2011 & 2012 & 2013 & 2014 & 2015 & 2016 & 2017 & 2018 & 2019 & 2020 & 2021 & 2022 & 2023 & 2024 & 2025 & 2026 \\
-\midrule
-Visual Studio 10 &  \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{yellow} & \cellcolor{red} & \cellcolor{red} & \cellcolor{red} & & \\
-GCC 4.2 & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{yellow} & \cellcolor{red} & \cellcolor{red} & \cellcolor{red} & \cellcolor{red} & \cellcolor{red} & & & & & \\
-GCC 4.4 & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{yellow} & \cellcolor{red} & \cellcolor{red} & \cellcolor{red} & \cellcolor{red} & \cellcolor{red} & & \\
-GCC 4.9 & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{itkTableCellGreen} & \cellcolor{yellow} & \cellcolor{red} \\
-\bottomrule
-\end{tabular}
-}
-\end{center}
-\itkcaption[ITK Compiler Support Timeline]{ITK Compiler Support Timeline.
-\label{tab:CompileSupportTimeline}}
-\end{table}
-
-\textbf{Legend}:
-
-\begin{table}[h]
-\begin{center}
-\begin{tabular}{l}
-\cellcolor{itkTableCellGreen}Fully supported \\
-\cellcolor{yellow}Phase out \\
-\cellcolor{red}If community supported \\
-\end{tabular}
-\end{center}
-\end{table}
 
 If you are currently using an outdated compiler this may be an excellent excuse
 for upgrading this old piece of software! Support for different platforms is

--- a/SoftwareGuide/Latex/Introduction/Introduction.tex
+++ b/SoftwareGuide/Latex/Introduction/Introduction.tex
@@ -22,7 +22,7 @@ advantage of the many resources available
 materials, which provide cookbook recipes that concisely demonstrate how to
 achieve a given task, the Doxygen pages, which document the specific algorithm
 parameters, and the knowledge of the many ITK community members (see Section
-\ref{sec:AdditionalResources} on page \pageref{sec:AdditionalResources}.)
+\ref{sec:AdditionalResources} on page \pageref{sec:AdditionalResources}).
 
 The Insight Toolkit is an open-source software system. This means that the
 community surrounding ITK has a great impact on the evolution of the software.
@@ -54,7 +54,7 @@ system, and be an active participant in the project.
 The key to learning how to use ITK is to become familiar with its palette of
 objects and the ways to combine them. There are three categories of
 documentation to help with the learning process: high level guidance material
-(the Software Guide), "cookbook" demonstrations on how to achieve concrete
+(the Software Guide), ``cookbook'' demonstrations on how to achieve concrete
 objectives (the examples), and detailed descriptions of the
 application programming interface (the
 Doxygen\footnote{\url{https://itk.org/Doxygen/index.html}} documentation). These
@@ -62,19 +62,18 @@ resources are combined in the three recommended stages for learning ITK.
 
 In the first stage, thoroughly read this introduction, which provides an
 overview of some of the key concepts of the system. It also provides guidance
-on how to build and install the software. After running your first "hello
-world" program, you are well on your way to advanced computational image
+on how to build and install the software. After running your first ``hello
+world'' program, you are well on your way to advanced computational image
 analysis!
 
 The next stage is to execute a few examples and gain familiarity with the
 available documentation. By running the examples, one can gain confidence
 in achieving results and is introduced the mechanics of the software system.
-There are three example resources,
+There are two example resources,
 \begin{enumerate}
   \item the \code{Examples} directory of the ITK source code repository
   \footnote{See Section~\nameref{sec:DownloadingITK} on
   page~\pageref{sec:DownloadingITK})}.
-  \item the Examples pages on the ITK Wiki \footnote{\url{https://itk.org/Wiki/ITK/Examples}}
   \item the Sphinx documented ITK Examples \footnote{\url{https://itk.org/ITKExamples}}
 \end{enumerate}
 To gain familiarity with the available documentation, browse the sections
@@ -116,55 +115,59 @@ repository.
 
 The \code{ITK} repository contains the following subdirectories:
 \begin{itemize}
-        \item \code{ITK/Modules} --- the heart of the software; the location
-        of the majority of the source code.
         \item \code{ITK/Documentation} --- migration guides and Doxygen infrastructure.
         \item \code{ITK/Examples} --- a suite of simple, well-documented
         examples used by this guide, illustrating important
         ITK concepts.
-        \item \code{ITK/Testing} --- a collection of the MD5 files, which are
-used to link with the ITK data servers to download test data. This test data is
-used by tests in \code{ITK/Modules} to produce the ITK Quality Dashboard using
-CDash.
+        \item \code{ITK/Modules} --- the heart of the software; the location
+        of the majority of the source code.
+        \item \code{ITK/Testing} --- a collection of the test files, including
+        raw binary, and MD5 and SHA512 hash files, which are used to link
+        with the ITK data servers to download test data. This test data is
+        used by tests in \code{ITK/Modules} to produce the ITK Quality
+        Dashboard using CDash.
         (see Section \ref{sec:CDash} on page \pageref{sec:CDash}.)
-        \item \code{Insight/Utilities} --- the scripts that support source code development. For example, CTest and Doxygen support.
-        \item \code{Insight/Wrapping} --- the wrapping code to build interfaces between the C++ library and various interpreted languages (currently Python is supported).
+        \item \code{ITK/Utilities} --- the scripts that support source code
+        development. For example, CTest and Doxygen support.
+        \item \code{ITK/Wrapping} --- the wrapping code to build interfaces
+        between the C++ library and various interpreted languages (currently
+        Python is supported).
 \end{itemize}
 
 The source code directory structure---found in \code{ITK/Modules}---is
 the most important to understand.
 \begin{itemize}
-        \item \code{ITK/Modules/Core} --- core classes, macro definitions,
-        type aliases, and other software constructs central to ITK. The classes
-        in \code{Core} are the only ones always compiled as part of ITK.
-        \item \code{ITK/Modules/ThirdParty} --- various third-party libraries
-        that are used to implement image file I/O and mathematical algorithms.
-        (Note: ITK's mathematical library is based
-        on the VXL/VNL software
-        package\footnote{\url{http://vxl.sourceforge.net}}.)
-        \item \code{ITK/Modules/Filtering} --- image processing filters.
-        \item \code{ITK/Modules/IO} --- classes that support the reading
-        and writing of images, transforms, and geometry.
         \item \code{ITK/Modules/Bridge} --- classes used to connect with the
         other analysis libraries or visualization libraries, such as
         OpenCV\footnote{\url{http://opencv.org}} and
         VTK\footnote{\url{http://www.vtk.org}}.
-        \item \code{ITK/Modules/Registration} --- classes for registration of
-        images or other data structures to each other.
-        \item \code{ITK/Modules/Segmentation} --- classes for segmentation of
-        images or other data structures.
-        \item \code{ITK/Modules/Video} --- classes for input, output and processing
-        of static and real-time data with temporal components.
         \item \code{ITK/Modules/Compatibility} --- collects together classes
         for backwards compatibility with ITK Version 3, and classes that are
         deprecated -- i.e. scheduled for removal from future versions of ITK.
+        \item \code{ITK/Modules/Core} --- core classes, macro definitions,
+        type aliases, and other software constructs central to ITK. The classes
+        in \code{Core} are the only ones always compiled as part of ITK.
+        \item \code{ITK/Modules/External} --- a directory to place in development
+        or non-publicized modules.
+        \item \code{ITK/Modules/Filtering} --- image processing filters.
+        \item \code{ITK/Modules/IO} --- classes that support the reading
+        and writing of images, transforms, and geometry.
+        \item \code{ITK/Modules/Numerics} --- a collection of numeric modules, including
+        FEM, Optimization, Statistics, Neural Networks, etc.
+        \item \code{ITK/Modules/Registration} --- classes for registration of
+        images or other data structures to each other.
         \item \code{ITK/Modules/Remote} --- a group of modules distributed outside
         of the main ITK source repository (most of them are hosted on \url{github.com})
         whose source code can be downloaded via CMake when configuring ITK.
-        \item \code{ITK/Modules/External} --- a directory to place in development
-        or non-publicized modules.
-        \item \code{ITK/Modules/Numerics} --- a collection of numeric modules, including
-        FEM, Optimization, Statistics, Neural Networks, etc.
+        \item \code{ITK/Modules/Segmentation} --- classes for segmentation of
+        images or other data structures.
+        \item \code{ITK/Modules/ThirdParty} --- various third-party libraries
+        that are used to implement image file I/O and mathematical algorithms.
+        (Note: ITK's mathematical library is based
+        on the VXL/VNL software
+        package\footnote{\url{https://vxl.github.io}}).
+        \item \code{ITK/Modules/Video} --- classes for input, output and processing
+        of static and real-time data with temporal components.
 \end{itemize}
 
 The Doxygen documentation is an essential resource when working with ITK, but


### PR DESCRIPTION
Miscellaneus fixes in the `Introduction` and `Installation` chapters:
- Fix the development environment names.
- Rework the compiler list: update to currently supported versions.
- Remove the compiler support/deprecation cycle table due to difficulties
  in keeping it up to date.
- Remove the deprecated reference to the Wiki Examples: examples are
  entirely hosted in https://itk.org/ITKExamples/ since a series of PRs
  including
  InsightSoftwareConsortium/ITKExamples#108 and
  InsightSoftwareConsortium/ITKExamples#109.
- Update the `vxl` link.
- Fix the `Utilities` and `Wrapping` parent folders.
- Mention the raw binary files and the SHA512 hash files in the `Testing`
  folder paragraph.
- Take advantage of the commit to order alphabetically the ITK's main
  folders.

Take advantage of the commit for other minor style changes (e.g. period at
the end of sentences, proper LaTex quote syntax, etc.).

Take advantage of the commit to limit the line length to 79 characters in
the ITK's folder structure bullet points.