### PR TITLE
ENH: Add missing table borders in `How To Create A Module` chapter

### DIFF
--- a/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
+++ b/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
@@ -601,7 +601,7 @@ prefix \code{ITKT\_}.
 
 \begin{table}
 \begin{center}
-\begin{tabular}{l | l | l |}
+\begin{tabular}{| l | l | l |}
 \hline
 & \textbf{CMake Variable} & \textbf{Value} \\
 \hline
@@ -649,7 +649,7 @@ their values for plain old datatypes (PODS).}
 \begin{table}
 \begin{center}
   \small
-  \begin{tabular}{l | p{0.3\textwidth} | p{0.5\textwidth} |}
+  \begin{tabular}{| l | p{0.3\textwidth} | p{0.5\textwidth} |}
 \hline
 & \textbf{CMake Variable} & \textbf{Value} \\
 \hline
@@ -692,7 +692,7 @@ their values for plain old datatypes (PODS).}
 \begin{table}
 \begin{center}
   \small
-  \begin{tabular}{l | p{0.3\textwidth} | p{0.5\textwidth} |}
+  \begin{tabular}{| l | p{0.3\textwidth} | p{0.5\textwidth} |}
 \hline
 & \textbf{CMake Variable} & \textbf{Value} \\
 \hline


### PR DESCRIPTION
Add missing table borders in `How To Create A Module` chapter.