### PR TITLE
DOC: Update copyright assignment to NumFOCUS

### DIFF
--- a/.hooks-config.bash
+++ b/.hooks-config.bash
@@ -1,6 +1,6 @@
 #==========================================================================
 #
-#   Copyright Insight Software Consortium
+#   Copyright NumFOCUS
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -326,7 +326,7 @@ as follows:
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
 /*=========================================================================
  *
- *  Copyright Insight Software Consortium
+ *  Copyright NumFOCUS
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -1675,7 +1675,7 @@ The class layout looks something like this:
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
 /*=========================================================================
  *
- *  Copyright Insight Software Consortium
+ *  Copyright NumFOCUS
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -1754,7 +1754,7 @@ The class definition layout looks something like this:
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
 /*=========================================================================
 *
-*  Copyright Insight Software Consortium
+*  Copyright NumFOCUS
 *
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
@@ -2313,7 +2313,7 @@ For instance,
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
 /*=========================================================================
  *
- *  Copyright Insight Software Consortium
+ *  Copyright NumFOCUS
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -2592,7 +2592,7 @@ For instance,
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
 /*=========================================================================
  *
- *  Copyright Insight Software Consortium
+ *  Copyright NumFOCUS
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -2684,7 +2684,7 @@ For instance,
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
 /*=========================================================================
  *
- *  Copyright Insight Software Consortium
+ *  Copyright NumFOCUS
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
+++ b/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
@@ -1031,9 +1031,8 @@ the Insight Journal article.
 it should be an Open Source Initiative-approved
 license\footnote{\url{https://opensource.org/licenses}} without copyleft or
 non-commercial restrictions. Ideally, it should be an Apache 2.0 license
-assigned to the Insight Software Consortium as found in the rest of the
-toolkit. Note that the module should contain neither patented code, nor
-algorithms, nor methods.
+assigned to NumFOCUS as found in the rest of the toolkit. Note that the module
+should contain neither patented code, nor algorithms, nor methods.
 \end{itemize}
 
 At the beginning of the release candidate phase of a release, maintainers of

--- a/Utilities/Hooks/commit-msg
+++ b/Utilities/Hooks/commit-msg
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #==========================================================================
 #
-#   Copyright Insight Software Consortium
+#   Copyright NumFOCUS
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/Utilities/Hooks/pre-commit
+++ b/Utilities/Hooks/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #==========================================================================
 #
-#   Copyright Insight Software Consortium
+#   Copyright NumFOCUS
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/Utilities/Hooks/prepare-commit-msg
+++ b/Utilities/Hooks/prepare-commit-msg
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #==========================================================================
 #
-#   Copyright Insight Software Consortium
+#   Copyright NumFOCUS
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/Utilities/SetupForDevelopment.sh
+++ b/Utilities/SetupForDevelopment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #==========================================================================
 #
-#   Copyright Insight Software Consortium
+#   Copyright NumFOCUS
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.


### PR DESCRIPTION
As part of the process of the Insight Software Consortium joining the
NumFOCUS non-profit corporation as a Fiscally Sponsored Project, all
assets, including intellectual property assets, are being transferred to
enable dissolution of the Insight Software Consortium non-profit
corporate legal entity.

The Insight Software Consortium Board of Directors resolved in the
2019-10-22 Meeting to assign ITK copyright to NumFOCUS and CMake and
IGSTK to Kitware. A copy of the signed copyright transfer documents can be
found in the corresponding pull request to ITK:
https://github.com/InsightSoftwareConsortium/ITK/pull/1598