### PR TITLE
DOC: Add `long long` specifier C++ and mangling types

### DIFF
--- a/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
+++ b/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
@@ -621,6 +621,9 @@ prefix \code{ITKT\_}.
 \textbf{Mangling} & ITKM\_UL & UL \\ \hline
 \textbf{C++ Type} & ITKT\_UL & unsigned long \\ \hline
 \\ \hline
+\textbf{Mangling} & ITKM\_ULL & ULL \\ \hline
+\textbf{C++ Type} & ITKT\_ULL & unsigned long long \\ \hline
+\\ \hline
 \textbf{Mangling} & ITKM\_SC & SC \\ \hline
 \textbf{C++ Type} & ITKT\_SC & signed char \\ \hline
 \\ \hline
@@ -632,6 +635,9 @@ prefix \code{ITKT\_}.
 \\ \hline
 \textbf{Mangling} & ITKM\_SL & SL \\ \hline
 \textbf{C++ Type} & ITKT\_SL & signed long \\ \hline
+\\ \hline
+\textbf{Mangling} & ITKM\_SLL & SLL \\ \hline
+\textbf{C++ Type} & ITKT\_SLL & signed long long \\ \hline
 \\ \hline
 \textbf{Mangling} & ITKM\_F & F \\ \hline
 \textbf{C++ Type} & ITKT\_F & float \\ \hline


### PR DESCRIPTION
Add `long long` specifier C++ and mangling types.