### PR TITLE
ENH: Add "Trailing Return Types" section

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -2985,6 +2985,47 @@ while( it != m_Container.end() )
 \normalsize
 
 
+\section{Trailing Return Types}
+\label{sec:TrailingReturnTypes}
+
+Whenever choosing between a trailing return type (as introduced with C++11) and
+the old form of having the return type before the function name (as was already
+supported by C++98), prefer the form that is the shortest, and the simplest.
+
+In the following example, the old form is preferred over a trailing return type:
+\small
+\begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
+// Preferred:
+template <typename T1, typename T2>
+bool
+AlmostEquals(T1 x1, T2 x2)
+
+// Rather than:
+template <typename T1, typename T2>
+auto
+AlmostEquals(T1 x1, T2 x2) -> bool
+\end{minted}
+\normalsize
+
+In the following example, a trailing return type is preferred over the old form:
+
+\small
+\begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
+
+// Preferred:
+template <typename TValue, unsigned int VLength>
+auto
+FixedArray<TValue, VLength>::Size() const -> SizeType
+
+// Rather than:
+template <typename TValue, unsigned int VLength>
+typename FixedArray<TValue, VLength>::SizeType
+FixedArray<TValue, VLength>::Size() const
+
+\end{minted}
+\normalsize
+
+
 \section{Empty Arguments in Methods}
 \label{sec:EmptyArgumentInMethods}
 


### PR DESCRIPTION
Adds a guideline in accordance with commit https://github.com/InsightSoftwareConsortium/ITK/commit/c54ad6715a68570f9db14f002c239ec7ea06383d
"COMP: Use trailing return type instead of typename + dependent type"

Discussed at pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2780
"Workaround VS2017 compile errors using-declarations"