### PR TITLE
COMP: Fix compile errors from *.cxx files in SoftwareGuide/Cover/Source

### DIFF
--- a/SoftwareGuide/Cover/Source/ModelBasedSegmentation.cxx
+++ b/SoftwareGuide/Cover/Source/ModelBasedSegmentation.cxx
@@ -282,7 +282,7 @@ int main( int argc, char *argv[] )
   MetricType::Pointer metric = MetricType::New();
 
 
-  using InterpolatorType itk::LinearInterpolateImageFunction<
+  using InterpolatorType = itk::LinearInterpolateImageFunction<
                                          ImageType, double >;
 
   InterpolatorType::Pointer interpolator = InterpolatorType::New();
@@ -393,7 +393,7 @@ int main( int argc, char *argv[] )
 
 
   try {
-    registration->StartRegistration();
+    registration->Update();
     }
   catch( const itk::ExceptionObject & exp ) {
     std::cerr << "Exception caught ! " << std::endl;

--- a/SoftwareGuide/Cover/Source/VWColorSegmentation.cxx
+++ b/SoftwareGuide/Cover/Source/VWColorSegmentation.cxx
@@ -29,7 +29,7 @@ int main(int argc, char * argv[] )
   using ImageReaderType = itk::ImageFileReader< ImageType >;
   using ImageWriterType = itk::ImageFileWriter< OutputImageType >;
 
-  using ConfidenceConnectedFilterType itk::VectorConfidenceConnectedImageFilter<
+  using ConfidenceConnectedFilterType = itk::VectorConfidenceConnectedImageFilter<
                                               ImageType,
                                               OutputImageType>;
 

--- a/SoftwareGuide/Cover/Source/VectorGradientAnisotropicDiffusionFilter.cxx
+++ b/SoftwareGuide/Cover/Source/VectorGradientAnisotropicDiffusionFilter.cxx
@@ -19,7 +19,7 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkVectorGradientAnisotropicDiffusionImageFilter.h"
-#include "itkVectorCastImageFilter.h"
+#include "itkCastImageFilter.h"
 #include "itkRGBPixel.h"
 
 
@@ -48,7 +48,7 @@ int main( int argc, char * argv[] )
 
   using WriterType = itk::ImageFileWriter< OutputImageType >;
 
-  using CasterType = itk::VectorCastImageFilter<
+  using CasterType = itk::CastImageFilter<
                                ImageType, OutputImageType >;
 
   using FilterType = itk::VectorGradientAnisotropicDiffusionImageFilter<


### PR DESCRIPTION
Fixed compile errors from Visual C++ 2019, saying:

> ModelBasedSegmentation.cxx(285,31): error C2059: syntax error: 'itk::LinearInterpolateImageFunction...
> ModelBasedSegmentation.cxx(288,3): error C2653: 'InterpolatorType': is not a class or namespace name

> ModelBasedSegmentation.cxx(396,19): error C2039: 'StartRegistration': is not a member of 'itk::ImageToSpatialObjectRegistrationMethod<ImageType,EllipseType>'

> VWColorSegmentation.cxx(32,44): error C2059: syntax error: 'itk::VectorConfidenceConnectedImageFilter...
> VWColorSegmentation.cxx(36,3): error C2653: 'ConfidenceConnectedFilterType': is not a class or namespace name

> VectorGradientAnisotropicDiffusionFilter.cxx(22,10): fatal error C1083: Cannot open include file: 'itkVectorCastImageFilter.h': No such file or directory