### PR TITLE
STYLE: Use `auto` for declaration of variables initialized by `New()`

### DIFF
--- a/SoftwareGuide/Cover/Source/AntialiasFilter.cxx
+++ b/SoftwareGuide/Cover/Source/AntialiasFilter.cxx
@@ -50,7 +50,7 @@ int main( int argc, char ** argv )
   using FilterType = itk::AntiAliasBinaryImageFilter<
                                InputImageType, OutputImageType >;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
 
   const double maximumRMSError = atof( argv[3] );
@@ -59,8 +59,8 @@ int main( int argc, char ** argv )
   filter->SetMaximumRMSError( maximumRMSError );
   filter->SetMaximumIterations( numberOfIterations );
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   const char * inputFilename  = argv[1];
   const char * outputFilename = argv[2];

--- a/SoftwareGuide/Cover/Source/BinaryMaskMedianFilter.cxx
+++ b/SoftwareGuide/Cover/Source/BinaryMaskMedianFilter.cxx
@@ -50,7 +50,7 @@ int main( int argc, char ** argv )
 
   using FilterType = itk::BinaryMedianImageFilter< ImageType, ImageType >;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
 
   unsigned int radius = atoi( argv[3] );
@@ -68,8 +68,8 @@ int main( int argc, char ** argv )
   filter->SetForegroundValue( 255 );
 
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   //
   // Here we recover the file names from the command line arguments

--- a/SoftwareGuide/Cover/Source/BinaryThresholdFilter.cxx
+++ b/SoftwareGuide/Cover/Source/BinaryThresholdFilter.cxx
@@ -30,11 +30,11 @@ int main(int argc, char * argv[] )
                                     InputImageType,
                                     OutputImageType >;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
   filter->ReleaseDataFlagOn();
 
-  ImageReaderType::Pointer imageReader = ImageReaderType::New();
+  auto imageReader = ImageReaderType::New();
   imageReader->SetFileName( argv[1] );
 
 
@@ -72,7 +72,7 @@ int main(int argc, char * argv[] )
     return -1;
     }
 
-  ImageWriterType::Pointer imageWriter = ImageWriterType::New();
+  auto imageWriter = ImageWriterType::New();
 
   imageWriter->SetFileName( argv[2] );
 

--- a/SoftwareGuide/Cover/Source/DilateFilter.cxx
+++ b/SoftwareGuide/Cover/Source/DilateFilter.cxx
@@ -58,7 +58,7 @@ int main( int argc, char ** argv )
                                   ImageType,
                                   StructuringElementType >;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
 
   unsigned int radius = atoi( argv[3] );
@@ -72,8 +72,8 @@ int main( int argc, char ** argv )
   filter->SetKernel(  structuringElement );
 
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   const char * inputFilename  = argv[1];
   const char * outputFilename = argv[2];

--- a/SoftwareGuide/Cover/Source/ImageReadExtractWriteRGB.cxx
+++ b/SoftwareGuide/Cover/Source/ImageReadExtractWriteRGB.cxx
@@ -55,7 +55,7 @@ int main( int argc, char ** argv )
 
   using FilterType = itk::RegionOfInterestImageFilter< ImageType, ImageType >;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
 
 
@@ -85,8 +85,8 @@ int main( int argc, char ** argv )
 
 
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
 
 

--- a/SoftwareGuide/Cover/Source/ModelBasedSegmentation.cxx
+++ b/SoftwareGuide/Cover/Source/ModelBasedSegmentation.cxx
@@ -257,7 +257,7 @@ int main( int argc, char *argv[] )
 
   using ImageType = itk::Image< float, Dimension >;
 
-  EllipseType::Pointer ellipse = EllipseType::New();
+  auto ellipse = EllipseType::New();
 
 
   EllipseType::ArrayType axis;
@@ -273,19 +273,19 @@ int main( int argc, char *argv[] )
                                       ImageType,
                                       EllipseType  >;
 
-  RegistrationType::Pointer registration = RegistrationType::New();
+  auto registration = RegistrationType::New();
 
 
   using MetricType = SimpleImageToSpatialObjectMetric<
                                            ImageType, EllipseType >;
 
-  MetricType::Pointer metric = MetricType::New();
+  auto metric = MetricType::New();
 
 
   using InterpolatorType itk::LinearInterpolateImageFunction<
                                          ImageType, double >;
 
-  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  auto interpolator = InterpolatorType::New();
 
 
   using OptimizerType = itk::OnePlusOneEvolutionaryOptimizer;
@@ -294,7 +294,7 @@ int main( int argc, char *argv[] )
 
 
   using TransformType = itk::TranslationTransform< double, Dimension >;
-  TransformType::Pointer transform = TransformType::New();
+  auto transform = TransformType::New();
 
 
   itk::Statistics::NormalVariateGenerator::Pointer generator
@@ -317,7 +317,7 @@ int main( int argc, char *argv[] )
 
   using IterationCallbackType = IterationCallback< OptimizerType >;
 
-  IterationCallbackType::Pointer callback = IterationCallbackType::New();
+  auto callback = IterationCallbackType::New();
 
   callback->SetOptimizer( optimizer );
 

--- a/SoftwareGuide/Cover/Source/NegateFilter.cxx
+++ b/SoftwareGuide/Cover/Source/NegateFilter.cxx
@@ -88,11 +88,11 @@ int main( int argc, char ** argv )
 
   using FilterType = itk::NegateImageFilter< ImageType >;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   //
   // Here we recover the file names from the command line arguments

--- a/SoftwareGuide/Cover/Source/RescaleIntensityFilter.cxx
+++ b/SoftwareGuide/Cover/Source/RescaleIntensityFilter.cxx
@@ -53,11 +53,11 @@ int main( int argc, char ** argv )
                                     InputImageType,
                                     OutputImageType >;
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
 
-  ReaderType::Pointer reader = ReaderType::New();
-  WriterType::Pointer writer = WriterType::New();
+  auto reader = ReaderType::New();
+  auto writer = WriterType::New();
 
   const char * inputFilename  = argv[1];
   const char * outputFilename = argv[2];

--- a/SoftwareGuide/Cover/Source/VWBlueRemoval.cxx
+++ b/SoftwareGuide/Cover/Source/VWBlueRemoval.cxx
@@ -26,7 +26,7 @@ int main(int argc, char * argv[] )
   ImageType::Pointer image;
 
   { // Local scoope for destroying the reader
-    ImageReaderType::Pointer imageReader = ImageReaderType::New();
+    auto imageReader = ImageReaderType::New();
     imageReader->SetFileName( argv[1] );
     try
       {
@@ -88,7 +88,7 @@ int main(int argc, char * argv[] )
     }
 
 
-  ImageWriterType::Pointer imageWriter = ImageWriterType::New();
+  auto imageWriter = ImageWriterType::New();
 
   imageWriter->SetFileName( argv[2] );
   imageWriter->SetInput( image );

--- a/SoftwareGuide/Cover/Source/VWColorSegmentation.cxx
+++ b/SoftwareGuide/Cover/Source/VWColorSegmentation.cxx
@@ -38,7 +38,7 @@ int main(int argc, char * argv[] )
 
   confidenceFilter->ReleaseDataFlagOn();
 
-  ImageReaderType::Pointer imageReader = ImageReaderType::New();
+  auto imageReader = ImageReaderType::New();
   imageReader->SetFileName( argv[1] );
 
   constexpr unsigned int VectorDimension = 3;
@@ -101,7 +101,7 @@ int main(int argc, char * argv[] )
     return -1;
     }
 
-  ImageWriterType::Pointer imageWriter = ImageWriterType::New();
+  auto imageWriter = ImageWriterType::New();
 
   imageWriter->SetFileName( argv[2] );
 

--- a/SoftwareGuide/Cover/Source/VWHistogramHSV.cxx
+++ b/SoftwareGuide/Cover/Source/VWHistogramHSV.cxx
@@ -84,7 +84,7 @@ int main(int argc, char * argv[] )
 
   { // local scope for destroying the reader
 
-    ReaderType::Pointer reader = ReaderType::New();
+    auto reader = ReaderType::New();
     reader->SetFileName( argv[1] );
     try
       {
@@ -111,7 +111,7 @@ int main(int argc, char * argv[] )
   region.SetSize( size );
   region.SetIndex( start );
 
-  OutputImageType::Pointer histogramImage = OutputImageType::New();
+  auto histogramImage = OutputImageType::New();
   histogramImage->SetRegions( region );
   histogramImage->Allocate();
   histogramImage->FillBuffer( 0 );
@@ -189,7 +189,7 @@ int main(int argc, char * argv[] )
 
   std::cout << "End of HSV histogram computation" << std::endl;
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName( argv[2] );
   writer->SetInput( histogramImage );

--- a/SoftwareGuide/Cover/Source/VWHistogramRGB.cxx
+++ b/SoftwareGuide/Cover/Source/VWHistogramRGB.cxx
@@ -32,7 +32,7 @@ int main(int argc, char * argv[] )
 
   { // local scope for destroying the reader
 
-    ReaderType::Pointer reader = ReaderType::New();
+    auto reader = ReaderType::New();
     reader->SetFileName( argv[1] );
     try
       {
@@ -59,7 +59,7 @@ int main(int argc, char * argv[] )
   region.SetSize( size );
   region.SetIndex( start );
 
-  OutputImageType::Pointer histogramImage = OutputImageType::New();
+  auto histogramImage = OutputImageType::New();
   histogramImage->SetRegions( region );
   histogramImage->Allocate();
   histogramImage->FillBuffer( 0 );
@@ -89,7 +89,7 @@ int main(int argc, char * argv[] )
     }
 
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   writer->SetFileName( argv[2] );
   writer->SetInput( histogramImage );

--- a/SoftwareGuide/Cover/Source/VectorGradientAnisotropicDiffusionFilter.cxx
+++ b/SoftwareGuide/Cover/Source/VectorGradientAnisotropicDiffusionFilter.cxx
@@ -55,10 +55,10 @@ int main( int argc, char * argv[] )
                        ImageType, ImageType >;
 
 
-  ReaderType::Pointer reader = ReaderType::New();
+  auto reader = ReaderType::New();
   reader->SetFileName( argv[1] );
 
-  FilterType::Pointer filter = FilterType::New();
+  auto filter = FilterType::New();
 
   filter->SetInput( reader->GetOutput() );
 
@@ -71,9 +71,9 @@ int main( int argc, char * argv[] )
 
   filter->Update();
 
-  CasterType::Pointer caster = CasterType::New();
+  auto caster = CasterType::New();
 
-  WriterType::Pointer writer = WriterType::New();
+  auto writer = WriterType::New();
 
   caster->SetInput( filter->GetOutput() );
   writer->SetInput( caster->GetOutput() );


### PR DESCRIPTION
Replaced initializations of the form `T::Pointer var = T::New()`
with `auto var = T::New()`, in accordance with ITK Coding Style section
"The auto Keyword", at
https://github.com/InsightSoftwareConsortium/ITKSoftwareGuide/blob/v5.2.1/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex#L1507-L1511

Using Notepad++ v8.1.4, Find in Files (Regular expression):

    Find what: (\w+)::Pointer[ ]+(\w+) = \1::New\(\);
    Replace with: auto $2 = $1::New\(\);

Corresponding ITK pull request: https://github.com/InsightSoftwareConsortium/ITK/pull/2826