### PR TITLE
DOC: Print backslash mark

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -274,8 +274,8 @@ The Doxygen open-source system is used to generate on-line documentation.
 Doxygen requires the embedding of simple comments in the code which is in turn
 extracted and formatted into documentation.
 
-Note that ITK prefers the backslash (``\\'') style versus the at-sign (``@'')
-style to write the documentation commands.
+Note that ITK prefers the backslash (\code{\textbackslash\textbackslash})
+style versus the at-sign (\code{@}) style to write the documentation commands.
 
 For more information about Doxygen, please visit
 \href{http://www.stack.nl/~dimitri/doxygen/}{http://www.stack.nl/~dimitri/doxygen/}
@@ -361,7 +361,7 @@ URL is written as it is (i.e. even if the maximum line width is exceeded). Do
 not use URL shortening services.
 
 When documenting a class header, if citations are required, use the Doxygen
-\code{\\par References} command to list the references in a separate and clearly
+\code{{\textbackslash}par References} command to list the references in a separate and clearly
 visible paragraph.
 
 For instance,


### PR DESCRIPTION
Print backslash mark.

Fixes:
```
Note that ITK prefers the backslash ("
") style versus the at-sign (“@”) style to write the documentation command
```

and
```
When documenting a class header, if citations are required, use the Doxygen
`par References` command to list the references in a separate and
clearly visible paragraph
```

Use the `code` command for the at-sign as well for the sake of
consistency.