### PR TITLE
DOC: Remove recursive inclusion of .h files

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -1877,7 +1877,6 @@ The class definition layout looks something like this:
 #ifndef itkImage_hxx
 #define itkImage_hxx
 
-#include "itkImage.h"
 #include "itkProcessObject.h"
 
 #include <algorithm>
@@ -2789,7 +2788,6 @@ For instance,
 #ifndef itkSpecializedImageFilter_hxx
 #define itkSpecializedImageFilter_hxx
 
-#include "itkSpecializedImageFilter.h"
 #include "itkProgressAccumulator.h"
 
 namespace itk


### PR DESCRIPTION
The .h files include the .hxx files, which in
turn include the original .h file.

Remove the recursive includes.

Following the change in ITK:
https://github.com/InsightSoftwareConsortium/ITK/pull/2958/commits/eec896842c1e4a54f4e894c2b3600b83279fd5ff