### PR TITLE
STYLE: Do not use `void` in empty function parameter list

### DIFF
--- a/CMake/ITK_CheckCCompilerFlag.cmake
+++ b/CMake/ITK_CheckCCompilerFlag.cmake
@@ -25,7 +25,7 @@ include(CheckCSourceCompiles)
 macro (ITK_CHECK_C_COMPILER_FLAG _FLAG _RESULT)
    set(SAFE_CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS}")
    set(CMAKE_REQUIRED_DEFINITIONS "${_FLAG}")
-   CHECK_C_SOURCE_COMPILES("int main(void) { return 0; }" ${_RESULT}
+   CHECK_C_SOURCE_COMPILES("int main() { return 0; }" ${_RESULT}
      # Some compilers do not fail with a bad flag
      FAIL_REGEX "warning: command line option .* is valid for .* but not for C"
                                                             # Apple gcc

--- a/SoftwareGuide/Cover/Source/ModelBasedSegmentation.cxx
+++ b/SoftwareGuide/Cover/Source/ModelBasedSegmentation.cxx
@@ -169,7 +169,7 @@ public:
     std::cout << "Number of points in the metric = " << static_cast<unsigned long>( m_PointList.size() ) << std::endl;
   }
 
-  unsigned int GetNumberOfParameters(void) const  {return SpaceDimension;};
+  unsigned int GetNumberOfParameters() const  {return SpaceDimension;};
 
   /** Get the Derivatives of the Match Measure */
   void GetDerivative( const ParametersType &,

--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -3142,7 +3142,7 @@ operator.
 
 Some of the more important object macros are:
 \begin{itemize}
-\item \code{itkNewMacro(T)}: Creates the static class method \code{New(void)}
+\item \code{itkNewMacro(T)}: Creates the static class method \code{New()}
 that interacts with the object factory to instantiate objects. The method
 returns a \code{SmartPointer<T>} properly reference counted.
 \item \code{itkTypeMacro(thisClass, superclass)}: Adds standard methods a
@@ -3252,7 +3252,7 @@ Methods throwing exceptions must indicate so in their declaration as in:
 \small
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
 /** Initialize the components related to supporting multiple threads. */
-virtual void MultiThreadingInitialize(void) throw (ExceptionObject);
+virtual void MultiThreadingInitialize() throw (ExceptionObject);
 \end{minted}
 \normalsize
 


### PR DESCRIPTION
Following ITK commits:

"STYLE: removing void if used in place of empty parameter list"
by Dženan Zukić (@dzenanz), 11 September 2018
https://github.com/InsightSoftwareConsortium/ITK/commit/60807f4abcfd7c4d42ddf93796d6acf272aa442b

"STYLE: Remove redundant void argument lists"
by Hans Johnson (@hjmjohnson), 20 February 2020
pull request https://github.com/InsightSoftwareConsortium/ITK/pull/1628
https://github.com/InsightSoftwareConsortium/ITK/commit/e6d859ecae955a4e2a44b9e60677093dc254a4ca

In accordance with C++ Core Guidelines, August 19, 2021:
"Don't use void as an argument type"
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#nl25-dont-use-void-as-an-argument-type

Clang-Tidy "modernize-redundant-void-arg" check:
https://clang.llvm.org/extra/clang-tidy/checks/modernize-redundant-void-arg.html
