### PR TITLE
DOC: Add "Integer Type Specifiers" section

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -1376,6 +1376,21 @@ GetUseVectorBasedAlgorithm() const
 \end{itemize}
 
 
+\subsection{Integer Type Specifiers}
+\label{subsec:IntegerTypeSpecifiers}
+
+Throughout the code base, the built-in type \code{unsigned int} is spelled exactly like that:
+``unsigned int'' (rather than just ``unsigned''). Other built-in integer types should in
+general be specified by their shortest form. For example, ``short'', ``long'', and ``long long''
+are preferred to ``signed short int'', ``signed long int'', and ``signed long long int''.
+
+Within the \code{itk} namespace, integer type aliases from C++ Standard headers for C library
+facilities (like \code{<cstdlib>} and \code{<cstdint>}) should generally be used without a \code{std::} prefix.
+For example, ``size\_t'', ``int8\_t'', and ``uintmax\_t'' are preferred to ``std::size\_t'',
+``std::int8\_t'', and ``std::uintmax\_t''. When using any of those type aliases, the ITK header file
+``itkIntTypes.h'' may need to be \code{\#include}d, to ensure that those types are declared within the
+\code{itk} namespace.
+
 \section{Namespaces}
 \label{sec:Namespaces}
 


### PR DESCRIPTION
Added coding style guidelines for specifying built-in integer types and
integer types from the C library.

Following recent ITK commits, authored by Lee Newberg (@Leengit):

pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3365
commit https://github.com/InsightSoftwareConsortium/ITK/commit/8c2c654f3deb8897f22cf9bbce5df3c6482f9a82
commit https://github.com/InsightSoftwareConsortium/ITK/commit/e03a94119d056c6e66365e59e17317d62e339102
"STYLE: Drop `signed` and `int` from some types"

pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3139
commit https://github.com/InsightSoftwareConsortium/ITK/commit/a812aa3cefc453a65d493752c186ce2fdc1a7a7d
"STYLE: Change unsigned to unsigned int."

pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3250
commit https://github.com/InsightSoftwareConsortium/ITK/commit/c173dfd803acf943d9ab80683ac4133fea29cdf5
"STYLE: Remove `std::` prefix from types that work without it"