### PR TITLE
ENH: Use https instead of http when https works

### DIFF
--- a/.hooks-config.bash
+++ b/.hooks-config.bash
@@ -6,7 +6,7 @@
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
 #
-#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
 #
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,

--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -11,10 +11,10 @@
 
 #
 # For further details regarding this file,
-# see http://www.cmake.org/Wiki/CMake_Testing_With_CTest#Customizing_CTest
+# see https://www.cmake.org/Wiki/CMake_Testing_With_CTest#Customizing_CTest
 #
 # and
-# http://www.kitware.com/blog/home/post/27
+# https://www.kitware.com/blog/home/post/27
 #
 #----------------------------------------------------------------------
 
@@ -159,9 +159,9 @@ set(CTEST_CUSTOM_WARNING_EXCEPTION
 
   # Suppressing warnings about GL_GLEXT_LEGACY, the link reported below
   # report a similar problem with GL_GLEXT_PROTOTYPE.
-  # http://lists.apple.com/archives/mac-opengl/2009/Dec/msg00081.html
+  # https://lists.apple.com/archives/mac-opengl/2009/Dec/msg00081.html
   # That problem could be solved installing a newer version of X11 SDK
-  # See http://xquartz.macosforge.org/trac/changeset/343
+  # See https://xquartz.macosforge.org/trac/changeset/343
   ".*warning.*GL_GLEXT_LEGACY.*redefined"
 
   # ITK suppressions
@@ -315,7 +315,7 @@ set(CTEST_CUSTOM_WARNING_EXCEPTION
 
   # Suppressing warnings about duplicate libraries in Darwin
   # At some point this may be addressed by CMake feature request:
-  # http://public.kitware.com/Bug/view.php?id=10179
+  # https://public.kitware.com/Bug/view.php?id=10179
   "ld.*warning.*duplicate dylib.*"
   )
 endif()

--- a/CMake/ExternalData.cmake
+++ b/CMake/ExternalData.cmake
@@ -55,7 +55,7 @@
 # Example usage:
 #   include(ExternalData)
 #   set(ExternalData_URL_TEMPLATES "file:///local/%(algo)/%(hash)"
-#                                  "http://data.org/%(algo)/%(hash)")
+#                                  "https://data.org/%(algo)/%(hash)")
 #   ExternalData_Add_Test(MyData
 #     NAME MyTest
 #     COMMAND MyExe DATA{MyInput.png}

--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -155,7 +155,7 @@ macro(check_compiler_platform_flags)
          # With MS compilers on Win64, we need the /bigobj switch, else generated
          # code results in objects with number of sections exceeding object file
          # format.
-         # see http://msdn.microsoft.com/en-us/library/ms173499.aspx
+         # see https://msdn.microsoft.com/en-us/library/ms173499.aspx
          if(MSVC_VERSION GREATER 1310)
            set(ITK_REQUIRED_CXX_FLAGS "${ITK_REQUIRED_CXX_FLAGS} /bigobj")
          endif()

--- a/CMake/SlicerMacroCheckExternalProjectDependency.cmake
+++ b/CMake/SlicerMacroCheckExternalProjectDependency.cmake
@@ -5,7 +5,7 @@
 #  Copyright (c) Kitware Inc.
 #
 #  See COPYRIGHT.txt
-#  or http://www.slicer.org/copyright/copyright.txt for details.
+#  or https://www.slicer.org/copyright/copyright.txt for details.
 #
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,

--- a/CMake/SlicerMacroEmptyExternalProject.cmake
+++ b/CMake/SlicerMacroEmptyExternalProject.cmake
@@ -8,7 +8,7 @@
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
 #
-#      http://www.commontk.org/LICENSE
+#      https://www.commontk.org/LICENSE
 #
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@
 #
 ###########################################################################
 
-# See http://github.com/commontk/CTK/blob/master/CMake/ctkMacroEmptyExternalProject.cmake
+# See https://github.com/commontk/CTK/blob/master/CMake/ctkMacroEmptyExternalProject.cmake
 
 #
 # Convenient macro allowing to define a "empty" project in case an external one is provided

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,6 @@ Some Helpful Git Commands
 
 
 [Git]: https://git-scm.com/
-[VIM]: http://www.vim.org/
+[VIM]: https://www.vim.org/
 [GitHub]: https://github.com/
 [Pull Request]: https://help.github.com/articles/about-pull-requests/

--- a/Latex/Insight.bib
+++ b/Latex/Insight.bib
@@ -35,7 +35,7 @@
 
 @Manual{POVRay,
   Title          = "Persistence of Vision, Ray-Tracer",
-  Address        = "http://www.povray.org",
+  Address        = "https://www.povray.org",
 }
 
 @Book{Romeny1994,
@@ -55,7 +55,7 @@
 @TechReport{Aisemberg,
   Author         = "G.O. Aisemberg",
   Title          = "Vertebrate embryology",
-  Address        = "http://lcw.lehman.edu/lehman/depts/biology/aisemberg/Bio268.html",
+  Address        = "https://lcw.lehman.edu/lehman/depts/biology/aisemberg/Bio268.html",
   Institution    = "Department of Biological Sciences. Lehman College,
                    City University of New York",
   year           = 1998,
@@ -758,7 +758,7 @@
   Title          = "Intrinsic scale for boundary representation of
                    two-dimensional objects",
   Institution    = "MIDAG, University of North Carolina at Chapel Hill",
-  annote         = "http://www.cs.unc.edu/~culver",
+  annote         = "https://www.cs.unc.edu/~culver",
   year           = 1999,
 }
 
@@ -824,7 +824,7 @@
   Institution    = "Unite de recherche INRIA Sophia-Antipolis",
   Number         = "1893",
   Note           = "Research Repport",
-  annote         = "http://www.inria.fr",
+  annote         = "https://www.inria.fr",
   year           = 1993,
   month          = "avril",
 }
@@ -832,7 +832,7 @@
 @Book{Darwin1999,
   Author         = "C. Darwin",
   Title          = "On the Origin of Species",
-  Publisher      = "http://www.gutenberg.org",
+  Publisher      = "https://www.gutenberg.org",
   Edition        = "sixth",
   year           = 1999,
 }
@@ -2753,7 +2753,7 @@
   Title          = "From Voxel to Curvature",
   Institution    = "INRIA",
   Number         = "1356",
-  Note           = "http://www.inria.fr",
+  Note           = "https://www.inria.fr",
   year           = 1990,
   month          = "decembre",
 }
@@ -2763,7 +2763,7 @@
   Title          = "Using Partial Derivatives of 3D Images to Extract
                    Typical Surface Features ",
   Institution    = "INRIA",
-  Note           = "http://www.inria.fr",
+  Note           = "https://www.inria.fr",
   year           = 1992,
 }
 
@@ -3490,7 +3490,7 @@
   Title          = "The OpenGL Graphics System: A Specification (Version
                    1.2)",
   Author         = "M. Segal and K. Akeley",
-  Address        = "http://www.opengl.org",
+  Address        = "https://www.opengl.org",
   month          = "march",
   year           = 1998,
 }
@@ -3908,7 +3908,7 @@
   Author         = "J. K. Udupa and S. Samarasekera",
   Title          = "Extraction of fuzzy object information in multidimensional images for quantifying MS lesions of the brain",
   year           = 1998,
-  Institution    = "United States Patent Office http://www.uspto.gov",
+  Institution    = "United States Patent Office https://www.uspto.gov",
   Number         = "5,812,691"
 }
 
@@ -4803,7 +4803,7 @@ Discipline},
   Title          = "The GDCM Library",
   Institution    = "CREATIS (France)",
   Organization   = "CNRS, INSERM, INSA Lyon, UCB Lyon",
-  Address        = "http://www.creatis.insa-lyon.fr/Public/Gdcm/"
+  Address        = "https://www.creatis.insa-lyon.fr/Public/Gdcm/"
 }
 
 @InProceedings{Chung2002,
@@ -4854,7 +4854,7 @@ Discipline},
   Title          = "OpenJPEG",
   Institution    = "Communications and Remote Sensing Laboratory (TELE)",
   Organization   = "Universit\'{e} Catholique de Louvain (UCL), Belgium",
-  Address        = "http://www.openjpeg.org"
+  Address        = "https://www.openjpeg.org"
 }
 
 @TechReport{JPEG2000KeyAdvantages,
@@ -4863,7 +4863,7 @@ Discipline},
   Institution    = "Aware Inc.",
   Year           = 2002,
   Month          = "February",
-  Address        = "http://medical.nema.org/Dicom/minutes/WG-04/2002/2002-02-27/Weisfeiler.doc"
+  Address        = "https://medical.nema.org/Dicom/minutes/WG-04/2002/2002-02-27/Weisfeiler.doc"
 }
 
 @inproceedings{ marcellin00overview,

--- a/Latex/gitdags.sty
+++ b/Latex/gitdags.sty
@@ -6,7 +6,7 @@
 %% of this license or (at your option) any later version.
 %% The latest version of this license is in
 %%
-%%     http://www.latex-project.org/lppl.txt
+%%     https://www.latex-project.org/lppl.txt
 %%
 %% and version 1.3 or later is part of all distributions of LaTeX
 %% version 2005/12/01 or later.
@@ -64,7 +64,7 @@
   }
 }
 
-% To cancel a shadow (see http://tex.stackexchange.com/a/198298/21891)
+% To cancel a shadow (see https://tex.stackexchange.com/a/198298/21891)
 \tikzset{reset preaction/.code={\def\tikz@preactions{}}}
 
 % --- repository history graphs ---

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ All the dependencies described belowe are available pre-installed in a [Docker]
 image. This is the easiest way to build and contribute to The Software
 Guide.
 
-  1. Download and [install Docker](http://docs.docker.com/installation/).
+  1. Download and [install Docker](https://docs.docker.com/installation/).
   2. From a shell, run
 ```sh
 docker run --name software-guide -p 8888:8888 insighttoolkit/itksoftwareguide-edit:latest
@@ -175,12 +175,12 @@ Troubleshooting
 
 [BibTeX]: http://www.bibtex.org/
 [Docker]: https://www.docker.com/
-[dvips]: http://tug.org/texinfohtml/dvips.html
+[dvips]: https://tug.org/texinfohtml/dvips.html
 [Git]: https://git-scm.com/
 [ImageMagick]: https://www.imagemagick.org
 [LaTeX]: https://www.latex-project.org//
 [Minted]: https://ctan.org/pkg/minted?lang=en
 [MikTex]: https://miktex.org/
 [ps2pdf]: https://www.ps2pdf.com/
-[Pygments]: http://pygments.org/
+[Pygments]: https://pygments.org/
 [Python]: https://www.python.org/

--- a/SoftwareGuide/Latex/01-PrintedPreamble-Common.tex
+++ b/SoftwareGuide/Latex/01-PrintedPreamble-Common.tex
@@ -26,7 +26,7 @@ and the \emph{Insight Software Consortium}
 
 \copyright \the\year \; Kitware, Inc. \emph{(cover, preface, postface)}\\
 \copyright \the\year \; Insight Software Consortium \emph{(main text body)}\\
-Published by Kitware, Inc. \texttt{http://www.kitware.com}
+Published by Kitware, Inc. \texttt{https://www.kitware.com}
 \normalsize
 \end{center}
 \end{minipage}

--- a/SoftwareGuide/Latex/02-Cover-Book1.tex
+++ b/SoftwareGuide/Latex/02-Cover-Book1.tex
@@ -21,7 +21,7 @@ resulted in an 3D image of $256\times256\times256$ pixels. The histogram
 image was visualized in VolView.\footnote{VolView is a commercial product
 from Kitware. It supports ITK plug-ins and is available as a free viewer or
 may be licensed with advanced functionality. See
-http://www.kitware.com/products/volview.html for information.} The cluster
+https://www.kitware.com/products/volview.html for information.} The cluster
 corresponding to the statistical distribution of blue values was identified
 visually, and a separating plane was manually defined in RGB space. The
 equation of this plane was subsequently used to discriminate pixels in the

--- a/SoftwareGuide/Latex/03-Abstract-Common.tex
+++ b/SoftwareGuide/Latex/03-Abstract-Common.tex
@@ -24,7 +24,7 @@ at run-time during program execution. It also means that many of ITK's
 algorithms can be applied to arbitrary spatial dimensions and pixel types.
 
 An automated wrapping system integrated with ITK generates an interface between
-C++ and a high-level programming language \href{http://www.python.org}{Python}.
+C++ and a high-level programming language \href{https://www.python.org}{Python}.
 This enables rapid prototyping and faster exploration of ideas by shortening the
 edit-compile-execute cycle. In addition to automated
 wrapping, the \href{https://www.itk.org/Wiki/SimpleITK}{SimpleITK} project
@@ -41,7 +41,7 @@ are communication and testing. Communication among the members of the
 ITK community is what helps manage the rapid evolution of the
 software. Testing is what keeps the software stable. An
 extensive testing process supported by the system known as
-\href{http://open.cdash.org/index.php?project=Insight}{CDash}
+\href{https://open.cdash.org/index.php?project=Insight}{CDash}
 measures the quality of ITK code on a daily basis. The ITK Testing Dashboard is
 updated continuously, reflecting the quality of the code at any moment.
 

--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -85,7 +85,7 @@ This style guide is an evolving chapter.
 Please discuss with the ITK community members if you wish to add, modify, or
 delete the rules described in these guidelines.
 
-See \href{http://www.itk.org/ITK/help/mailing.html}{http://www.itk.org/ITK/help/mailing.html}
+See \href{https://www.itk.org/ITK/help/mailing.html}{https://www.itk.org/ITK/help/mailing.html}
 for more information about joining the ITK community members discussion. This
 forum is one of the best venues in which to propose changes to these style
 guidelines.
@@ -154,7 +154,7 @@ A growing number of ITK classes offer a Python wrapping. Note that these are
 wrappers on the C++ counterparts. ITK's Python wrappers can be easily installed.
 See Section~\ref{sec:ModuleWrapping} on page~\pageref{sec:ModuleWrapping} for
 further details. Users requiring a Python interface for ITK classes may refer to
-SimpleITK (\href{http://www.simpleitk.org/}{http://www.simpleitk.org/}).
+SimpleITK (\href{https://www.simpleitk.org/}{https://www.simpleitk.org/}).
 
 Additionally, SimpleITK offers interpreted language bindings for Java, C\#, R,
 Tcl, and Ruby.
@@ -270,7 +270,7 @@ The ITK build environment is CMake. CMake is an open-source, advanced
 cross-platform build system that enables community members to write simple
 makefiles (named \code{CMakeLists.txt}) that are processed to generated native
 build tools for a particular operating system/compiler combination. See the
-CMake web pages at \href{http://www.cmake.org}{http://www.cmake.org} for more
+CMake web pages at \href{https://www.cmake.org}{https://www.cmake.org} for more
 information.
 
 See Section~\ref{sec:UsingCMakeForConfiguringAndBuildingITK} on page
@@ -346,7 +346,7 @@ as follows:
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0.txt
+ *       https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -1097,8 +1097,8 @@ For template parameters the use of \code{typename} is preferred over
 and \code{class} was purposed for declaring template parameters. It was later
 discovered that this lead to ambiguity in some valid code constructs, and the
 \code{typename} key word was added. It is often agreed
-(\href{http://blogs.msdn.com/b/slippman/archive/2004/08/11/212768.aspx}
-{http://blogs.msdn.com/b/slippman/archive/2004/08/11/212768.aspx}) that
+(\href{https://blogs.msdn.com/b/slippman/archive/2004/08/11/212768.aspx}
+{https://blogs.msdn.com/b/slippman/archive/2004/08/11/212768.aspx}) that
 \code{typename} is marginally more expressive in its intent and ITK should
 consistently use \code{typename} instead of \code{class}.
 
@@ -1793,7 +1793,7 @@ The class layout looks something like this:
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0.txt
+ *       https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -1877,7 +1877,7 @@ The class definition layout looks something like this:
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -2428,7 +2428,7 @@ For instance,
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0.txt
+ *       https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -2710,7 +2710,7 @@ For instance,
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -2804,7 +2804,7 @@ For instance,
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -4032,8 +4032,8 @@ the documentation. While there are a large number of options to Doxygen,
 ITK community members are required at a minimum to insert Doxygen commands
 listed in this section.
 
-See more at \href{http://www.stack.nl/~dimitri/doxygen/}
-{http://www.stack.nl/~dimitri/doxygen/}
+See more at \href{https://www.stack.nl/~dimitri/doxygen/}
+{https://www.stack.nl/~dimitri/doxygen/}
 
 
 \subsection{General Principles}

--- a/SoftwareGuide/Latex/Appendices/GitWorkflow.tex
+++ b/SoftwareGuide/Latex/Appendices/GitWorkflow.tex
@@ -9,7 +9,7 @@ and flexible model to develop modern software.
 \section{Git Setup}
 \label{sec:Git Setup}
 
-Visit the main \href{http://www.git-scm.com/download}{Git download site}, and
+Visit the main \href{https://www.git-scm.com/download}{Git download site}, and
 depending on your operating system, follow the guidelines.
 
 
@@ -121,7 +121,7 @@ rambling collection of tips and experiences that I've picked up in the last
 few years of using Git.
 
 It is worth trying to explain some high-level Git concepts. A
-\href{http://carthik.net/blog/vault/2007/08/21/its-a-feature-not-a-bug/}{feature}
+\href{https://carthik.net/blog/vault/2007/08/21/its-a-feature-not-a-bug/}{feature}
 (or a
 \href{https://blog.codinghorror.com/thats-not-a-bug-its-a-feature-request/}{bug})
 that sets Git apart from Subversion is its distributed nature. In practice,

--- a/SoftwareGuide/Latex/Appendices/Licenses.tex
+++ b/SoftwareGuide/Latex/Appendices/Licenses.tex
@@ -102,7 +102,7 @@ We are required to state that
 
 \subsection{Netlib's SLATEC}
 This code is in the public domain.  From
-\url{http://www.netlib.org/slatec/guide}:
+\url{https://www.netlib.org/slatec/guide}:
 \begin{verbatim}
 SECTION 4.  OBTAINING THE LIBRARY
 

--- a/SoftwareGuide/Latex/Architecture/DataRepresentation.tex
+++ b/SoftwareGuide/Latex/Architecture/DataRepresentation.tex
@@ -10,7 +10,7 @@ for representing data in ITK. The most common classes are
 \label{sec:ImageSection}
 
 The \doxygen{Image} class follows the spirit of
-\href{http://www.boost.org/more/generic_programming.html}{Generic Programming},
+\href{https://www.boost.org/more/generic_programming.html}{Generic Programming},
 where types are separated from the algorithmic behavior of the class.
 ITK supports images with any pixel type and any spatial dimension.
 

--- a/SoftwareGuide/Latex/Architecture/SystemOverview.tex
+++ b/SoftwareGuide/Latex/Architecture/SystemOverview.tex
@@ -22,7 +22,7 @@ in some cases additional chapters---cover these concepts in more detail.
 
   \item[Numerics.] ITK uses VXL's VNL numerics libraries. These are
         easy-to-use C++ wrappers around the Netlib Fortran numerical
-        analysis routines \footnote{\url{http://www.netlib.org}}.
+        analysis routines \footnote{\url{https://www.netlib.org}}.
 
   \item[Data Representation and Access.] Two principal classes are
         used to represent data: the \doxygen{Image} and \doxygen{Mesh}
@@ -81,7 +81,7 @@ in some cases additional chapters---cover these concepts in more detail.
         tool is used to produce an XML description of arbitrarily complex C++
         code. An interface generator script is then used to transform the XML
         description into wrappers using the
-        SWIG\footnote{\url{http://www.swig.org/}} package.
+        SWIG\footnote{\url{https://www.swig.org/}} package.
 
 \end{description}
 
@@ -545,10 +545,10 @@ The VNL numerics library includes classes for:
 Most VNL routines are implemented as wrappers around the high-quality Fortran
 routines that have been developed by the numerical analysis community over
 the last forty years and placed in the public domain. The central repository
-for these programs is the ``netlib'' server.\footnote{\url{http://www.netlib.org/}} The
+for these programs is the ``netlib'' server.\footnote{\url{https://www.netlib.org/}} The
 National Institute of Standards and Technology (NIST) provides an excellent
 search interface to this repository in its \emph{Guide to Available Mathematical
-Software (GAMS)},\footnote{\url{http://gams.nist.gov}} both as a decision tree and a
+Software (GAMS)},\footnote{\url{https://gams.nist.gov}} both as a decision tree and a
 text search.
 
 ITK also provides additional numerics functionality. A suite of optimizers, that

--- a/SoftwareGuide/Latex/DesignAndFunctionality/ConfidenceConnectedOnBrainWeb.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/ConfidenceConnectedOnBrainWeb.tex
@@ -1,6 +1,6 @@
 \subsubsection{Application of the Confidence Connected filter on the Brain Web Data}
 This section shows some results obtained by applying the Confidence Connected filter on the BrainWeb database. The filter was applied on a 181 $\times$ 217 $\times$ 181 crosssection of the {\it brainweb165a10f17} dataset. The data is a MR T1 acquisition, with an intensity non-uniformity of 20\% and a slice thickness 1mm. The dataset may be obtained from
-\code{http://www.bic.mni.mcgill.ca/brainweb/} or
+\code{https://www.bic.mni.mcgill.ca/brainweb/} or
 \code{https://data.kitware.com/\#folder/5882712d8d777f4f3f3072df}
 
 The previous code was used in this example replacing the image dimension by 3.

--- a/SoftwareGuide/Latex/DesignAndFunctionality/IO.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/IO.tex
@@ -196,8 +196,8 @@ dealing with reading and writing series of images.
 With the introduction of computed tomography (CT) followed by other digital
 diagnostic imaging modalities such as MRI in the 1970's, and the increasing use
 of computers in clinical applications, the American College of Radiology
-(ACR)\footnote{\url{http://www.acr.org}} and the National Electrical
-Manufacturers Association (NEMA)\footnote{\url{http://www.nema.org}} recognized
+(ACR)\footnote{\url{https://www.acr.org}} and the National Electrical
+Manufacturers Association (NEMA)\footnote{\url{https://www.nema.org}} recognized
 the need for a standard method for transferring images as well as associated
 information between devices manufactured from various vendors.
 
@@ -240,13 +240,13 @@ clinical setting are stored and transported using the DICOM standard.
 
 DICOM functionalities in ITK are provided by the GDCM library. This open source
 library was developed by the CREATIS
-Team~\footnote{\url{http://www.creatis.insa-lyon.fr}} at
+Team~\footnote{\url{https://www.creatis.insa-lyon.fr}} at
 INSA-Lyon~\cite{CreatisINSA-Lyon}.  Although originally this library was
 distributed under a LGPL
-License\footnote{\url{http://www.gnu.org/copyleft/lesser.html}}, the CREATIS Team was
+License\footnote{\url{https://www.gnu.org/copyleft/lesser.html}}, the CREATIS Team was
 lucid enough to understand the limitations of that license and agreed to adopt
 the more open BSD-like
-License\footnote{\url{http://www.opensource.org/licenses/bsd-license.php}}.
+License\footnote{\url{https://www.opensource.org/licenses/bsd-license.php}}.
 This change in their licensing made possible to distribute GDCM
 along with ITK.
 

--- a/SoftwareGuide/Latex/DesignAndFunctionality/Registration.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/Registration.tex
@@ -520,7 +520,7 @@ the ITK users list.
 \subsection{Too many samples outside moving image buffer}
 
 
-http://public.kitware.com/pipermail/insight-users/2007-March/021442.html
+https://public.kitware.com/pipermail/insight-users/2007-March/021442.html
 
 This is a common error message in image registration.
 
@@ -568,7 +568,7 @@ accounted for.
 
 
 
-http://public.kitware.com/pipermail/insight-users/2007-March/021435.html
+https://public.kitware.com/pipermail/insight-users/2007-March/021435.html
 
 Here is some advice on how to fine tune the parameters
 of the registration process.

--- a/SoftwareGuide/Latex/DesignAndFunctionality/VisualizingDeformationFieldsUsingParaview.tex
+++ b/SoftwareGuide/Latex/DesignAndFunctionality/VisualizingDeformationFieldsUsingParaview.tex
@@ -9,7 +9,7 @@
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Vector deformation fields may be visualized using ParaView.
-ParaView \cite{ParaviewBook} is an open-source, multi-platform visualization application and uses the Visualization Toolkit as the data processing and rendering engine and has a user interface written using a unique blend of Tcl/Tk and C++. You may download it from http://paraview.org.
+ParaView \cite{ParaviewBook} is an open-source, multi-platform visualization application and uses the Visualization Toolkit as the data processing and rendering engine and has a user interface written using a unique blend of Tcl/Tk and C++. You may download it from https://paraview.org.
 
 \subsection{Visualizing 2D deformation fields}
 Let us visualize the deformation field obtained from Demons Registration algorithm generated from ITK/Examples/RegistrationITKv4/DeformableRegistration2.cxx.

--- a/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
+++ b/SoftwareGuide/Latex/DevelopmentGuidelines/CreateAModule.tex
@@ -1326,7 +1326,7 @@ A Module may be developed outside the main ITK repository, but it may be
 made available in the ITK repository as a Remote Module. The Remote Module
 infrastructure enables fast dissemination of research code through ITK without
 increasing the size of the main repository. The Insight Journal
-(\url{http://www.insight-journal.org/}) adds support for ITK module submissions
+(\url{https://www.insight-journal.org/}) adds support for ITK module submissions
 with automatic dashboard testing (see Section~\ref{sec:CDash} on
 page~\pageref{sec:CDash} for further details).
 

--- a/SoftwareGuide/Latex/DevelopmentGuidelines/SoftwareProcess.tex
+++ b/SoftwareGuide/Latex/DevelopmentGuidelines/SoftwareProcess.tex
@@ -68,7 +68,7 @@ page~\pageref{ch:ITKGitWorkflow}.
 \index{CDash}
 
 One of the unique features of the ITK software process is its use of the CDash
-regression testing system (\url{http://www.cdash.org}). In a
+regression testing system (\url{https://www.cdash.org}). In a
 nutshell, what CDash does is to provide quantifiable feedback to developers as
 they check in new code and make changes. The feedback consists of the results
 of a variety of tests, and the results are posted on a publicly-accessible
@@ -94,7 +94,7 @@ control for any software project. It is itself an open-source package and can
 be obtained from
 
 \begin{center}
-\url{http://www.cdash.org}
+\url{https://www.cdash.org}
 \end{center}
 
 CDash supports a variety of test types. These include the following.
@@ -234,5 +234,5 @@ routinely catches errors in vendor's graphics drivers (e.g., OpenGL drivers)
 or changes to external subsystems such as the VXL/VNL numerics library. All
 of these tools that make up the process (CMake, Git, and CDash) are
 open-source. Many large and small systems such as VTK (The Visualization
-Toolkit \url{http://www.vtk.org}) use the same process with similar
+Toolkit \url{https://www.vtk.org}) use the same process with similar
 results. We encourage the adoption of the process in your environment.

--- a/SoftwareGuide/Latex/Introduction/Installation.tex
+++ b/SoftwareGuide/Latex/Introduction/Installation.tex
@@ -69,7 +69,7 @@ than the code available from the Git repository (see Section
 \ref{sec:DownloadingFromGit}).  When working from the
 repository, please be aware of the ITK quality testing dashboard. The Insight
 Toolkit is heavily tested using the open-source CDash regression testing
-system\footnote{\url{http://open.cdash.org/index.php?project=Insight}}. Before
+system\footnote{\url{https://open.cdash.org/index.php?project=Insight}}. Before
 updating the repository, make sure that the dashboard is \emph{green},
 indicating stable code. (Learn more about the ITK dashboard and quality
 assurance process in Section \ref{sec:CDash} on page \pageref{sec:CDash}.)
@@ -127,7 +127,7 @@ organization of the software and joining the discussion.
 
 The Insight Toolkit was designed to support the Visible Human Project
 and its associated data. This data is available from the National Library of
-Medicine at \url{http://www.nlm.nih.gov/research/visible/visible_human.html}.
+Medicine at \url{https://www.nlm.nih.gov/research/visible/visible_human.html}.
 
 Another source of data can be obtained from the ITK Web site at either
 of the following:

--- a/SoftwareGuide/Latex/Introduction/Introduction.tex
+++ b/SoftwareGuide/Latex/Introduction/Introduction.tex
@@ -139,8 +139,8 @@ the most important to understand.
 \begin{itemize}
         \item \code{ITK/Modules/Bridge} --- classes used to connect with the
         other analysis libraries or visualization libraries, such as
-        OpenCV\footnote{\url{http://opencv.org}} and
-        VTK\footnote{\url{http://www.vtk.org}}.
+        OpenCV\footnote{\url{https://opencv.org}} and
+        VTK\footnote{\url{https://www.vtk.org}}.
         \item \code{ITK/Modules/Compatibility} --- collects together classes
         for backwards compatibility with ITK Version 3, and classes that are
         deprecated -- i.e. scheduled for removal from future versions of ITK.
@@ -233,7 +233,7 @@ number of possibilities. For details on participation, see Part III of this book
        ITK in proposed work.
 
        \item For those developing commercial applications with ITK, support
-       and consulting are available from Kitware \footnote{\url{http://www.kitware.com}}.
+       and consulting are available from Kitware \footnote{\url{https://www.kitware.com}}.
        Kitware also offers short ITK courses either at a site of your choice
        or periodically at Kitware offices.
 

--- a/Utilities/GitSetup/NOTICE
+++ b/Utilities/GitSetup/NOTICE
@@ -2,4 +2,4 @@ Kitware Local Git Setup Scripts
 Copyright 2010-2012 Kitware, Inc.
 
 This product includes software developed at Kitware, Inc.
-(http://www.kitware.com/).
+(https://www.kitware.com/).

--- a/Utilities/GitSetup/config.sample
+++ b/Utilities/GitSetup/config.sample
@@ -3,7 +3,7 @@
 # Copy to "config" and edit as necessary.
 
 [hooks]
-	url = http://public.kitware.com/GitSetup.git
+	url = https://public.kitware.com/GitSetup.git
 	#branch = hooks
 
 [ssh]
@@ -17,6 +17,6 @@
 
 [gerrit]
 	#project = Project
-	site = http://review.source.kitware.com
+	site = https://review.source.kitware.com
 	# pushurl placeholder "$username" is literal
 	pushurl = $username@review.source.kitware.com:Project

--- a/Utilities/GitSetup/git-review-push
+++ b/Utilities/GitSetup/git-review-push
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Utilities/GitSetup/github-tips
+++ b/Utilities/GitSetup/github-tips
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Utilities/GitSetup/setup-github
+++ b/Utilities/GitSetup/setup-github
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Utilities/GitSetup/setup-hooks
+++ b/Utilities/GitSetup/setup-hooks
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Utilities/GitSetup/setup-ssh
+++ b/Utilities/GitSetup/setup-ssh
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Utilities/GitSetup/setup-stage
+++ b/Utilities/GitSetup/setup-stage
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Utilities/GitSetup/setup-upstream
+++ b/Utilities/GitSetup/setup-upstream
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Utilities/GitSetup/setup-user
+++ b/Utilities/GitSetup/setup-user
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Utilities/GitSetup/tips
+++ b/Utilities/GitSetup/tips
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Utilities/Hooks/commit-msg
+++ b/Utilities/Hooks/commit-msg
@@ -7,7 +7,7 @@
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
 #
-#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
 #
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,

--- a/Utilities/Hooks/pre-commit
+++ b/Utilities/Hooks/pre-commit
@@ -7,7 +7,7 @@
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
 #
-#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
 #
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,

--- a/Utilities/Hooks/prepare-commit-msg
+++ b/Utilities/Hooks/prepare-commit-msg
@@ -7,7 +7,7 @@
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
 #
-#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
 #
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,

--- a/Utilities/SetupForDevelopment.sh
+++ b/Utilities/SetupForDevelopment.sh
@@ -7,7 +7,7 @@
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
 #
-#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
 #
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
https is more tamper-resistant and more private so we use it instead
of http when it is available.

Following
https://github.com/InsightSoftwareConsortium/ITK/pull/3428/commits/9cd0f2053f0cf181ec4412bf896301faf0cc2092