### PR TITLE
ENH: Switch Github Actions Linux environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build-publish-pdf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Switch Github Actions Linux environment version to `ubuntu-20.04`.

`ubuntu-18.04` is being deprecated and support will end by 12/1/2022:
https://github.com/actions/virtual-environments/issues/6002

Related to recent warnings in the Azure Pipelines Linux environment
being used in the main ITK repository:
https://github.com/InsightSoftwareConsortium/ITK/pull/3554/commits/497c3a7b8e1397ca56a2675ce846dca657af8861