### PR TITLE
ENH: Fix the `Documentation` PR title identification

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,7 @@ type:Compiler:
 type:Bug:
   title: "^BUG:.*"
 
-area:Documentation:
+type:Documentation:
   title: "^DOC:.*"
 
 type:Enhancement:


### PR DESCRIPTION
Fix the `Documentation`PR title identification: avoid having two entries for the `area:Documentation` label, and use the newly created `type:Documentation` for the PR title regex.