### PR TITLE
ENH: Update GitHub Actions Ubuntu environment version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build-publish-pdf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
           curl \
           git \
           ninja-build \
-          python
+          python3
         # Using --no-install-recommends greatly reduces the installed packages
         sudo apt-get install -y --no-install-recommends \
           texlive-latex-base \
@@ -39,8 +39,8 @@ jobs:
           ghostscript \
           locales \
           imagemagick \
-          python \
-          python-pygments \
+          python3 \
+          python3-pygments \
           texlive-latex-recommended \
           tex4ht \
           texlive-fonts-recommended


### PR DESCRIPTION
Update GitHub Actions Ubuntu environment to version `22.04` in the interest of consistency with the rest of the versions used across ITK.

Change the Python package names:
- Use `python3` instead of `python`
- Use `python3-pygments` instead of `python-pygments`

as the latter no longer exist in Ubuntu `22.04`:
https://packages.ubuntu.com/jammy/python/