### PR TITLE
ENH: Update Python version in GitHub Actions to 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Install build dependencies
       run: |


### PR DESCRIPTION
Update Python version in GitHub Actions to 3.9: Python 3.7 will be deprecated on 27 Jun 2023:
https://endoflife.date/python

Make the version consistent with the version used in the ITK Python wrapping Azure Pipelines CI, and the ITK Sphinx Examples.