### PR TITLE
DOC: Remove mistaken exception to data member initialization guideline

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -1621,19 +1621,6 @@ SpecializedFilter<TInputImage, TOutputImage>::SpecializedFilter()
 \end{minted}
 \normalsize
 
-Nevertheless, there may be some exceptions to the initialization list rule. In
-some situations where it can be foreseen that the corresponding
-\code{Set\#\#name} or \code{\#\#nameOn}/\code{\#\#nameOff} may be
-
-\begin{itemize}
-\item overloaded by some classes in the future, or
-\item deprecated, and a warning thrown when it is called to help migration,
-\end{itemize}
-
-initialization through the corresponding \code{Set\#\#name} or
-\code{\#\#nameOn}/\code{\#\#nameOff} method is recommended instead of directly
-manipulating the data member.
-
 Smart pointers need not to be initialized, since they initialize themselves
 to the \code{null} pointer, so they are the sole exception to the above rule.
 


### PR DESCRIPTION
When a data member is set by a "setter" member function (`Set##name`, `On`, or `Off`), it is still recommended to initialize the member according to this guideline. Doing so prevents problems like the one addressed by pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3845 commit https://github.com/InsightSoftwareConsortium/ITK/commit/a31e8bf32a5ebe522e367976227cb4bda84f45e9 "BUG: Fix uninitialized value ImageRegistrationMethodv4::m_NumberOfLevels" by Jon Haitz Legarreta Gorroño (@jhlegarreta), 10 January 2023