### PR TITLE
DOC: Avoid using initialization lists in coding style snippets

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -2241,14 +2241,9 @@ And for a class constructor we would write
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
 template <typename TInputImage, typename TOutputImage>
 SpecializedFilter<TInputImage, TOutputImage>::SpecializedFilter()
-  : m_ForegroundValue(NumericTraits<InputImagePixelType>::max())
-  , m_BackgroundValue{}
-  , m_NumPixelComponents(0)
-  , m_NoiseSigmaIsSet(false)
-  , m_SearchSpaceList(ListAdaptorType::New())
 {
-  // By default, turn off automatic kernel bandwidth sigma estimation
-  this->KernelBandwidthEstimationOff();
+  // The filter requires two inputs
+  this->SetNumberOfRequiredInputs(2);
 }
 \end{minted}
 \normalsize


### PR DESCRIPTION
Avoid using initialization lists in coding style code snippets: initialization lists are not encouraged as per current ITK style guidelines.

Similarly, avoid using a boolean ivar setter method in the constructor, as ivars should be initialized when they are declared.