### PR TITLE
DOC: Avoid documenting ivar default values

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -4203,7 +4203,7 @@ value is using ``On'' for \code{true} and ``Off'' for \code{false}:
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
 /** Set/Get direction along the gradient to search.
  * Set to true to use the direction that the gradient is pointing;
- * set to false for the opposite direction. Default is Off. */
+ * set to false for the opposite direction. */
 itkGetConstMacro(Polarity, bool);
 itkSetMacro(Polarity, bool);
 itkBooleanMacro(Polarity);


### PR DESCRIPTION
Avoid documenting ivar default values since:
- All ivar values should be initialized to some default value.
- When default values are changed, it is easy to forget about updating the documentation and making it inconsistent with the actual value in the code.