### PR TITLE
DOC: Do not encourage using empty comment lines

### DIFF
--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -2900,9 +2900,8 @@ itkHMinimaImageFilterTest(int argc, char * argv[])
 
 
 However, it is preferable to use a single empty line and use a comment block
-using the \code{//} character to describe the part of the code at issue. The
-comment block can start and end with an empty comment line (\code{//}), and
-immediately be followed by the code, as in:
+using the \code{//} character to describe the part of the code at issue, as
+in:
 
 \small
 \begin{minted}[baselinestretch=1,fontsize=\footnotesize,linenos=false,bgcolor=ltgray]{cpp}
@@ -2920,10 +2919,7 @@ itkHMinimaImageFilterTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  //
-  // The following code defines the input and output pixel types and their
-  // associated image types.
-  //
+  // Define the input and output pixel types and their associated image types.
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = short;


### PR DESCRIPTION
Do not encourage using empty comment lines.

Take advantage of the commit to reword the example comment, removing unnecessary wording.