### PR TITLE
DOC: Replace `itkTypeMacro` with `itkOverrideGetNameOfClassMacro`

### DIFF
--- a/SoftwareGuide/Cover/Source/ModelBasedSegmentation.cxx
+++ b/SoftwareGuide/Cover/Source/ModelBasedSegmentation.cxx
@@ -39,7 +39,7 @@ public:
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
 
-  itkTypeMacro(IterationCallback, Superclass);
+  itkOverrideGetNameOfClassMacro(IterationCallback);
   itkNewMacro(Self);
 
   /** Type defining the optimizer */
@@ -118,7 +118,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SimpleImageToSpatialObjectMetric, ImageToSpatialObjectMetric);
+  itkOverrideGetNameOfClassMacro(SimpleImageToSpatialObjectMetric);
 
   enum
   {

--- a/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
+++ b/SoftwareGuide/Latex/Appendices/CodingStyleGuide.tex
@@ -2109,7 +2109,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(SpecializedFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(SpecializedFilter);
 
   ...
 };
@@ -2228,7 +2228,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(SpecializedFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(SpecializedFilter);
 
   // ...
 };
@@ -3228,9 +3228,8 @@ Some of the more important object macros are:
 \item \code{itkNewMacro(T)}: Creates the static class method \code{New()}
 that interacts with the object factory to instantiate objects. The method
 returns a \code{SmartPointer<T>} properly reference counted.
-\item \code{itkTypeMacro(thisClass, superclass)}: Adds standard methods a
-class, mainly type information. Adds the \code{GetNameOfClass()} method to the
-class.
+\item \code{itkOverrideGetNameOfClassMacro(thisClass)}: Adds an override of
+the \code{GetNameOfClass()} method to the class.
 \item \code{ITK\_DISALLOW\_COPY\_AND\_ASSIGN(TypeName)}: Disallow copying by
 declaring copy constructor and assignment operator deleted. This must be
 declared in the \textbf{public} section.
@@ -3297,7 +3296,7 @@ information (RTTI):
 itkNewMacro(Self);
 
 /** Run-time type information (and related methods). */
-itkTypeMacro(Image, ImageBase);
+itkOverrideGetNameOfClassMacro(Image);
 \end{minted}
 \normalsize
 

--- a/SoftwareGuide/Latex/DevelopmentGuidelines/WriteAFilter.tex
+++ b/SoftwareGuide/Latex/DevelopmentGuidelines/WriteAFilter.tex
@@ -532,7 +532,7 @@ factory mechanism, and to be created using the canonical \code{::New()}:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ExampleImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ExampleImageFilter);
 \end{minted}
 
 The default constructor should be \code{protected}, and provide sensible


### PR DESCRIPTION
Following ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4373/ commit https://github.com/InsightSoftwareConsortium/ITK/commit/2c264ea2ef62e916c6ef947599ce659cc8fce5fe "STYLE: Replace itkTypeMacro calls with `itkOverrideGetNameOfClassMacro`"