### PR TITLE
DOC: Fix PDF file properties in Book 2

### DIFF
--- a/SoftwareGuide/Art/ImageRegistration1TraceMetric.eps
+++ b/SoftwareGuide/Art/ImageRegistration1TraceMetric.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration1TraceTranslations.eps
+++ b/SoftwareGuide/Art/ImageRegistration1TraceTranslations.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration4TraceMetric.eps
+++ b/SoftwareGuide/Art/ImageRegistration4TraceMetric.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration4TraceTranslations.eps
+++ b/SoftwareGuide/Art/ImageRegistration4TraceTranslations.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration4TraceTranslations2.eps
+++ b/SoftwareGuide/Art/ImageRegistration4TraceTranslations2.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration5TraceAngle1.eps
+++ b/SoftwareGuide/Art/ImageRegistration5TraceAngle1.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration5TraceAngle2.eps
+++ b/SoftwareGuide/Art/ImageRegistration5TraceAngle2.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration5TraceMetric1.eps
+++ b/SoftwareGuide/Art/ImageRegistration5TraceMetric1.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration5TraceMetric2.eps
+++ b/SoftwareGuide/Art/ImageRegistration5TraceMetric2.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration5TraceTranslations1.eps
+++ b/SoftwareGuide/Art/ImageRegistration5TraceTranslations1.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration5TraceTranslations2.eps
+++ b/SoftwareGuide/Art/ImageRegistration5TraceTranslations2.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration6TraceAngle.eps
+++ b/SoftwareGuide/Art/ImageRegistration6TraceAngle.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration6TraceMetric.eps
+++ b/SoftwareGuide/Art/ImageRegistration6TraceMetric.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration6TraceTranslations.eps
+++ b/SoftwareGuide/Art/ImageRegistration6TraceTranslations.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration7TraceAngle.eps
+++ b/SoftwareGuide/Art/ImageRegistration7TraceAngle.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration7TraceMetric.eps
+++ b/SoftwareGuide/Art/ImageRegistration7TraceMetric.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration7TraceScale.eps
+++ b/SoftwareGuide/Art/ImageRegistration7TraceScale.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration7TraceTranslations.eps
+++ b/SoftwareGuide/Art/ImageRegistration7TraceTranslations.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration8TraceAngle.eps
+++ b/SoftwareGuide/Art/ImageRegistration8TraceAngle.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration8TraceMetric.eps
+++ b/SoftwareGuide/Art/ImageRegistration8TraceMetric.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration8TraceTranslations.eps
+++ b/SoftwareGuide/Art/ImageRegistration8TraceTranslations.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration9TraceAngle.eps
+++ b/SoftwareGuide/Art/ImageRegistration9TraceAngle.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration9TraceMetric.eps
+++ b/SoftwareGuide/Art/ImageRegistration9TraceMetric.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/ImageRegistration9TraceTranslations.eps
+++ b/SoftwareGuide/Art/ImageRegistration9TraceTranslations.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/MultiResImageRegistration1TraceMetric.eps
+++ b/SoftwareGuide/Art/MultiResImageRegistration1TraceMetric.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def

--- a/SoftwareGuide/Art/MultiResImageRegistration1TraceTranslations.eps
+++ b/SoftwareGuide/Art/MultiResImageRegistration1TraceTranslations.eps
@@ -22,7 +22,7 @@ gnudict begin
 /Level1 false def
 /Rounded false def
 /ClipToBoundingBox false def
-/SuppressPDFMark false def
+/SuppressPDFMark true def
 /TransparentPatterns false def
 /gnulinewidth 5.000 def
 /userlinewidth gnulinewidth def


### PR DESCRIPTION
Fix the PDF file properties: set the `SupressPDFMark` variable to `true` in the `eps` files.

The properties of the eps figures generated by gnuplot at the time the PDF is generated were ovewriting the LaTeX `hyperref` settings of the book, effectively modifying the title, author, subject, and keywords of the PDF file.

Relevant thread:
https://groups.google.com/g/comp.graphics.apps.gnuplot/c/WTjwj-lbC90
