### PR TITLE
COMP: Bump ITK to v5.4.6

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -104,8 +104,8 @@ if(NOT ( DEFINED "${extProjName}_DIR" OR ( DEFINED "USE_SYSTEM_${extProjName}" A
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
   if("${${proj}_GIT_TAG}" STREQUAL "")
-    # ITK release branch 2025-06-11
-    set(${proj}_GIT_TAG "v5.4.4")
+    # ITK release branch 2026-04-20
+    set(${proj}_GIT_TAG "v5.4.6")
   endif()
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
Bump the SuperBuild's pinned ITK tag from `v5.4.4` to `v5.4.6` so the guide's code examples build against the 5.4.6 release. Part of the InsightSoftwareConsortium/ITK#6092 release checklist ("Update ITKSoftwareGuide").

<details>
<summary>Diff</summary>

```diff
-    # ITK release branch 2025-06-11
-    set(${proj}_GIT_TAG "v5.4.4")
+    # ITK release branch 2026-04-20
+    set(${proj}_GIT_TAG "v5.4.6")
```

</details>

<details>
<summary>Base branch</summary>

Retargeted to the newly-created `release-5.4` branch (forked from tag `v5.4.4` at 2026-04-21). `main` has moved on to `v6.0b02` and is tracking the 6.0 development line, so patch bumps for the 5.4.x series land here.

</details>

<!--
provenance: claude-code session 2026-04-21
related_issue: InsightSoftwareConsortium/ITK#6092
release_branch_created: refs/heads/release-5.4 @ v5.4.4 (296ba7e) on 2026-04-21
itk_tag_date: v5.4.6 was tagged on 2026-04-20 15:27:03 -0400
post_merge_action: tag merge commit as v5.4.6 on ITKSoftwareGuide
-->
