### PR TITLE
DOC: Define itkref and itksubref Doxygen reference macros

### DIFF
--- a/SoftwareGuide/SoftwareGuideConfiguration.tex.in
+++ b/SoftwareGuide/SoftwareGuideConfiguration.tex.in
@@ -15,12 +15,17 @@
 \itkFullVersiontrue
 
 % Define command to make reference to on-line Doxygen documentation
-\newcommand{\doxygen}[1]{
+\newcommand{\itkref}[1]{
 \href{https://www.itk.org/Doxygen/html/classitk_1_1#1.html}{\code{itk::#1}}}
 
 % Define command to make reference to on-line Doxygen documentation
-\newcommand{\subdoxygen}[2]{
+\newcommand{\itksubref}[2]{
 \href{https://www.itk.org/Doxygen/html/classitk_1_1#1_1_1#2.html}{\code{itk::#1::#2}}}
+
+% Deprecated spellings of \itkref / \itksubref, kept for ITK branches that
+% still use them in their Software Guide example blocks.
+\newcommand{\doxygen}[1]{\itkref{#1}}
+\newcommand{\subdoxygen}[2]{\itksubref{#1}{#2}}
 
 % Define command for the standard comment introducing classes with similar functionalities
 \newcommand{\relatedClasses}{


### PR DESCRIPTION
Define `\itkref`/`\itksubref` LaTeX macros for Doxygen references, companion to InsightSoftwareConsortium/ITK#6416 (which renames the `\doxygen`/`\subdoxygen` spellings in ITK's Software Guide example blocks). The old names remain as aliases for ITK branches that still use them. **Merge before ITK#6416** so Guide builds keep working across the rename.

<!--
provenance: claude-code session 2026-06-11
companion_to: InsightSoftwareConsortium/ITK#6416
merge_order: this PR first, then ITK#6416
-->
